### PR TITLE
Clean up snowflake-telemetry db.user comments to reflect latest

### DIFF
--- a/samples/streamlit-in-snowflake/snowflake-telemetry/README.md
+++ b/samples/streamlit-in-snowflake/snowflake-telemetry/README.md
@@ -38,8 +38,9 @@ The sample app in this repo also has a basic example for querying and rendering 
 
 Telemetry for Streamlit in Snowflake has the following limitations currently. We are working to improve these.
 
-- App name is not captured automatically in `RESOURCE_ATTRIBUTES`. `snow.executable.type` shows `"PROCEDURE"` instead of `"STREAMLIT"`.
-- `db.user` does not capture the app viewer. Current workaround: Set `st.experimental_user.user_name` in your events manually.
+- App name is not captured automatically in `RESOURCE_ATTRIBUTES`.
+- `snow.executable.type` shows `"PROCEDURE"` instead of `"STREAMLIT"`.
+- Display title of the app is not captured automatically.
 - Events take a few minutes to propagate to event table starting when the app session is closed.
 - You can record only 128 events per app session.
 - `TRACE_LEVEL` and `LOG_LEVEL` parameters cannot be set at Streamlit object level - only account, database or schema.

--- a/samples/streamlit-in-snowflake/snowflake-telemetry/streamlit_app.py
+++ b/samples/streamlit-in-snowflake/snowflake-telemetry/streamlit_app.py
@@ -13,12 +13,7 @@ hifives_val = st.slider("High fives", 0, 20, 10)
 
 if st.button("Record event"):
     # Call telemetry.add_event() with an event name and any object attributes
-    telemetry.add_event("Recording Streamlit event",
-                        {
-                            "hifives_val": hifives_val,
-                            "viewer": st.experimental_user.user_name,
-                        }
-                       )
+    telemetry.add_event("Recording Streamlit event", {"hifives_val": hifives_val})
     st.success("Recorded the event!")
 
 with st.expander("View previously logged events"):
@@ -29,7 +24,7 @@ with st.expander("View previously logged events"):
                 select TIMESTAMP,
                 RESOURCE_ATTRIBUTES['snow.database.name'] as DATABASE,
                 RESOURCE_ATTRIBUTES['snow.schema.name'] as SCHEMA,
-                RESOURCE_ATTRIBUTES['db.user'] as USER, -- Pending st.experimental_user integration
+                RESOURCE_ATTRIBUTES['db.user'] as USER,
                 RECORD['name'] as RECORD,
                 TO_JSON(RECORD_ATTRIBUTES) as ATTRIBUTES
                 from {event_table}


### PR DESCRIPTION
`db.user` now shows the expected user name (the app viewer) in RESOURCE_ATTRIBUTES. Workaround is not required. Updated the doc and example to reflect that.