### PR TITLE
update mmt import path after image 1.4.2 release

### DIFF
--- a/samples/ml/many_model_training/mmt_example.ipynb
+++ b/samples/ml/many_model_training/mmt_example.ipynb
@@ -5,12 +5,12 @@
    "name": "streamlit"
   },
   "lastEditStatus": {
-   "notebookId": "ucm55dechyf6d3w2ogql",
-   "authorId": "2713708608032",
+   "notebookId": "jobukmxnx2hlc57l2aro",
+   "authorId": "4914184347444",
    "authorName": "ADMIN",
    "authorEmail": "",
-   "sessionId": "33ca66a0-d346-42c2-9f9d-5910d10ad644",
-   "lastEditTime": 1747264746928
+   "sessionId": "b6e0ca98-7629-4295-a565-3110c90f9173",
+   "lastEditTime": 1748905981827
   }
  },
  "nbformat_minor": 5,
@@ -214,7 +214,7 @@
     "name": "async_many_model_train"
    },
    "outputs": [],
-   "source": "from snowflake.ml.modeling.distributors.many_model_training.ray_approach.ray_implementation import ManyModelTrainer\nfrom snowflake.ml.modeling.distributors.many_model_training.many_model_trainer import RayExecutionOptions\n\nsnowpark_df = _init_snowpark_df(session)\nmodel_name=\"my_mmt_model\"\nmodel_version_v1 = \"v1\"\ntrainer = ManyModelTrainer(\n    training_func=user_training_func,\n    model_name=model_name,\n    model_version=model_version_v1,\n    stage_name=stage_name,\n    # execution_options is optional. When running in a multi-node setting, it's recommended setting use_head_node=False to exclude head node from doing actual training, this improves overall MMT training reliability.\n    # execution_options=RayExecutionOptions(use_head_node=False)\n)\n\ntrainer.run(snowpark_dataframe=snowpark_df, partition_by=\"LOCATION_ID\")\n",
+   "source": "from snowflake.ml.modeling.distributors.many_model_training.many_model_trainer import (\n    ManyModelTrainer,\n)\nfrom snowflake.ml.modeling.distributors.many_model_training.entities import (\n    ExecutionOptions,\n)\n\nsnowpark_df = _init_snowpark_df(session)\nmodel_name=\"my_mmt_model\"\nmodel_version_v1 = \"v1\"\ntrainer = ManyModelTrainer(\n    training_func=user_training_func,\n    model_name=model_name,\n    model_version=model_version_v1,\n    stage_name=stage_name,\n    # execution_options is optional. When running in a multi-node setting, it's recommended setting use_head_node=False to exclude head node from doing actual training, this improves overall MMT training reliability.\n    # execution_options=ExecutionOptions(use_head_node=False)\n)\n\ntrainer.run(snowpark_dataframe=snowpark_df, partition_by=\"LOCATION_ID\")\n",
    "execution_count": null
   },
   {
@@ -423,7 +423,7 @@
     "name": "cell11"
    },
    "outputs": [],
-   "source": "\nfrom snowflake.ml.modeling.distributors.many_model_training.ray_approach.read_only_many_model_trainer import ReadOnlyManyModelTrainer\n\n# Restore the trained model using the model name, version, and stage name\nread_only_trainer = ReadOnlyManyModelTrainer.restore_from(\n    model_name=model_name, \n    model_version=\"v1\", \n    stage_name=stage_name\n)\n\n# Check the status of the trained model\nmodel_status = read_only_trainer.status\nprint(model_status)\n\n# You can also access other APIs to inspect logs and metadata (except for .run())\nread_only_trainer.get_progress()\n",
+   "source": "\nfrom snowflake.ml.modeling.distributors.many_model_training.read_only_many_model_trainer import (\n    ReadOnlyManyModelTrainer,\n)\n\n# Restore the trained model using the model name, version, and stage name\nread_only_trainer = ReadOnlyManyModelTrainer.restore_from(\n    model_name=model_name, \n    model_version=\"v1\", \n    stage_name=stage_name\n)\n\n# Check the status of the trained model\nmodel_status = read_only_trainer.status\nprint(model_status)\n\n# You can also access other APIs to inspect logs and metadata (except for .run())\nread_only_trainer.get_progress()\n",
    "execution_count": null
   }
  ]


### PR DESCRIPTION
This changed the mmt import path to following now that 1.4.2 image has already hit production

```

from snowflake.ml.modeling.distributors.many_model_training.many_model_trainer import (
    ManyModelTrainer,
)
from snowflake.ml.modeling.distributors.many_model_training.entities import (
    ExecutionOptions,
)
from snowflake.ml.modeling.distributors.many_model_training.read_only_many_model_trainer import (
    ReadOnlyManyModelTrainer,
)
```