### PR TITLE
SNOW-2102070: fix data connector in the HPO example

### DIFF
--- a/samples/ml/container_runtime_hpo/hpo_example.ipynb
+++ b/samples/ml/container_runtime_hpo/hpo_example.ipynb
@@ -18,12 +18,12 @@
    "version": "3.11.8"
   },
   "lastEditStatus": {
-   "notebookId": "z6jl2rfb4v2eagigg5h4",
-   "authorId": "2713708608032",
-   "authorName": "ADMIN",
-   "authorEmail": "",
-   "sessionId": "9f597282-7256-4ed6-820f-0ba636e46cc3",
-   "lastEditTime": 1745884766725
+   "notebookId": "b3m3ta2fnit2z7tl5mkf",
+   "authorId": "3862350591012",
+   "authorName": "KLI",
+   "authorEmail": "kunle.li@snowflake.com",
+   "sessionId": "ef1c1acc-3f26-44e3-99b4-89e755645374",
+   "lastEditTime": 1752185807138
   }
  },
  "nbformat_minor": 5,
@@ -47,13 +47,14 @@
     "language": "python"
    },
    "outputs": [],
-   "source": "import xgboost as xgb\nimport pandas as pd\nfrom snowflake.ml.data.data_connector import DataConnector\nfrom snowflake.ml.modeling import tune\nfrom snowflake.ml.modeling.tune import get_tuner_context\nfrom sklearn import datasets\nfrom entities import search_algorithm\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.metrics import accuracy_score\nfrom snowflake.snowpark.context import get_active_session\n"
+   "source": "import xgboost as xgb\nfrom snowflake.ml.data.data_connector import DataConnector\nfrom snowflake.ml.modeling import tune\nfrom snowflake.ml.modeling.tune import get_tuner_context\nfrom sklearn import datasets\nfrom entities import search_algorithm\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.metrics import accuracy_score\nfrom snowflake.snowpark.context import get_active_session"
   },
   {
    "cell_type": "markdown",
    "id": "0cd6b014-666f-4c5f-9454-36094ff907cc",
    "metadata": {
-    "name": "cell3"
+    "name": "cell3",
+    "collapsed": false
    },
    "source": [
     "### Data Ingestion & Define Training Function"
@@ -65,7 +66,8 @@
    "id": "88471178-1087-4ff7-9009-34c82860f132",
    "metadata": {
     "name": "cell4",
-    "language": "python"
+    "language": "python",
+    "codeCollapsed": false
    },
    "outputs": [
     {
@@ -119,7 +121,7 @@
      ]
     }
    ],
-   "source": "######### STEP 0: FOLLOWING CODE SHOULD ALREADY BE AUTO-GENERATED IN SNOWFLAKE NOTEBOOK ##########\n\nsession = get_active_session()\n\n    \n######### STEP 1: GENERATE ARTIFICIAL TRAINING DATA FOR ILLUSTRATION PURPOSES ##########\nX, y = datasets.load_digits(return_X_y=True, as_frame=True)\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\ndataset_map = {\n    \"x_train\": DataConnector.from_dataframe(session.create_dataframe(X_train)),\n    \"y_train\": DataConnector.from_dataframe(\n        session.create_dataframe(y_train.to_frame())\n    ),\n    \"x_test\": DataConnector.from_dataframe(session.create_dataframe(X_test)),\n    \"y_test\": DataConnector.from_dataframe(\n        session.create_dataframe(y_test.to_frame())\n    ),\n}\n\n\n######### STEP 2: DEFINE TRAINING FUNCTION ##########\ndef train_func():\n    tuner_context = get_tuner_context()\n    config = tuner_context.get_hyper_params()\n    dm = tuner_context.get_dataset_map()\n    model = xgb.XGBClassifier(\n        **{k: int(v) if k != \"learning_rate\" else v for k, v in config.items()},\n        random_state=42,\n    )\n    model.fit(dm[\"x_train\"].to_pandas(), dm[\"y_train\"].to_pandas())\n    accuracy = accuracy_score(\n        dm[\"y_test\"].to_pandas(), model.predict(dm[\"x_test\"].to_pandas())\n    )\n    tuner_context.report(metrics={\"accuracy\": accuracy}, model=model)\n\n"
+   "source": "######### STEP 0: FOLLOWING CODE SHOULD ALREADY BE AUTO-GENERATED IN SNOWFLAKE NOTEBOOK ##########\n\nsession = get_active_session()\n    \n######### STEP 1: GENERATE ARTIFICIAL TRAINING DATA FOR ILLUSTRATION PURPOSES ##########\nX, y = datasets.load_digits(return_X_y=True, as_frame=True)\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.2, random_state=42\n)\nX_train = X_train.assign(target=y_train).reset_index(drop=True)\nX_test = X_test.assign(target=y_test).reset_index(drop=True)\ndataset_map = {\n    \"train\": DataConnector.from_dataframe(session.create_dataframe(X_train)),\n    \"test\": DataConnector.from_dataframe(session.create_dataframe(X_test)),\n}\n\n######### STEP 2: DEFINE TRAINING FUNCTION ##########\ndef train_func():\n    tuner_context = get_tuner_context()\n    config = tuner_context.get_hyper_params()\n    dm = tuner_context.get_dataset_map()\n    train_df = dm[\"train\"].to_pandas()\n    test_df = dm[\"test\"].to_pandas()\n    train_labels = train_df['\"target\"']\n    train_features = train_df.drop(columns=['\"target\"'])\n    test_labels = test_df['\"target\"']\n    test_features = test_df.drop(columns=['\"target\"'])\n    model = xgb.XGBClassifier(\n        **{k: int(v) if k != \"learning_rate\" else v for k, v in config.items()},\n        random_state=42,\n    )\n    model.fit(train_features, train_labels)\n    accuracy = accuracy_score(\n        test_labels, model.predict(test_features)\n    )\n    tuner_context.report(metrics={\"accuracy\": accuracy}, model=model)"
   },
   {
    "cell_type": "markdown",
@@ -138,7 +140,7 @@
     "name": "cell17"
    },
    "outputs": [],
-   "source": "from snowflake.ml.runtime_cluster import scale_cluster\n\nscale_cluster(2) # scale up from single node to two nodes\n",
+   "source": "from snowflake.ml.runtime_cluster import scale_cluster\n\nscale_cluster(2) # scale up from single node to two nodes",
    "execution_count": null
   },
   {
@@ -160,7 +162,7 @@
     "name": "cell19"
    },
    "outputs": [],
-   "source": "######### STEP 3: START HPO RUN With Bayes Opt Search ##########\n\ntuner = tune.Tuner(\n    train_func=train_func,\n    search_space={\n        \"n_estimators\": tune.uniform(50, 200),\n        \"max_depth\": tune.uniform(3, 10),\n        \"learning_rate\": tune.uniform(0.01, 0.3),\n    },\n    tuner_config=tune.TunerConfig(\n        metric=\"accuracy\",\n        mode=\"max\",\n        search_alg=search_algorithm.BayesOpt(),\n        num_trials=4, # Increase num_trials for broader exploration and potentially better model performance\n    ),\n)\n\ntuner_results = tuner.run(dataset_map=dataset_map)",
+   "source": "######### STEP 3: START HPO RUN With Bayes Opt Search ##########\ntuner = tune.Tuner(\n    train_func=train_func,\n    search_space={\n        \"n_estimators\": tune.uniform(50, 200),\n        \"max_depth\": tune.uniform(3, 10),\n        \"learning_rate\": tune.uniform(0.01, 0.3),\n    },\n    tuner_config=tune.TunerConfig(\n        metric=\"accuracy\",\n        mode=\"max\",\n        search_alg=search_algorithm.BayesOpt(),\n        num_trials=3, # Increase num_trials for broader exploration and potentially better model performance\n    ),\n)\n\ntuner_results = tuner.run(dataset_map=dataset_map)",
    "execution_count": null
   },
   {
@@ -169,7 +171,8 @@
    "id": "f35fe984-7a3a-4b99-a1db-0c150d82f5d1",
    "metadata": {
     "name": "cell7",
-    "language": "python"
+    "language": "python",
+    "codeCollapsed": false
    },
    "outputs": [
     {
@@ -238,7 +241,8 @@
    "id": "e7245736-08b7-4c0e-88d3-c40f4dbfd81b",
    "metadata": {
     "name": "cell9",
-    "language": "python"
+    "language": "python",
+    "codeCollapsed": false
    },
    "outputs": [
     {
@@ -695,7 +699,8 @@
    "cell_type": "markdown",
    "id": "931db453-efd3-4c81-b79f-417a42f2834b",
    "metadata": {
-    "name": "cell10"
+    "name": "cell10",
+    "collapsed": false
    },
    "source": [
     "### Random Search"
@@ -819,7 +824,7 @@
      ]
     }
    ],
-   "source": "######### START HPO RUN With Random Search ##########\n\ntuner = tune.Tuner(\n    train_func=train_func,\n    search_space={\n        \"n_estimators\": tune.uniform(50, 200),\n        \"max_depth\": tune.uniform(3, 10),\n        \"learning_rate\": tune.uniform(0.01, 0.3),\n    },\n    tuner_config=tune.TunerConfig(\n        metric=\"accuracy\",\n        mode=\"max\",\n        search_alg=search_algorithm.RandomSearch(),\n        num_trials=2,  # Increase num_trials for broader exploration and potentially better model performance\n    ),\n)\n\ntuner_results = tuner.run(dataset_map=dataset_map)"
+   "source": "######### START HPO RUN With Random Search ##########\n\ntuner = tune.Tuner(\n    train_func=train_func,\n    search_space={\n        \"n_estimators\": tune.uniform(50, 200),\n        \"max_depth\": tune.uniform(3, 10),\n        \"learning_rate\": tune.uniform(0.01, 0.3),\n    },\n    tuner_config=tune.TunerConfig(\n        metric=\"accuracy\",\n        mode=\"max\",\n        search_alg=search_algorithm.RandomSearch(),\n        num_trials=3,  # Increase num_trials for broader exploration and potentially better model performance\n    ),\n)\n\ntuner_results = tuner.run(dataset_map=dataset_map)"
   },
   {
    "cell_type": "code",
@@ -827,7 +832,8 @@
    "id": "9dcd4bb3-5312-4be9-9e10-3cbb0fee146e",
    "metadata": {
     "name": "cell12",
-    "language": "python"
+    "language": "python",
+    "codeCollapsed": false
    },
    "outputs": [
     {
@@ -906,7 +912,8 @@
    "cell_type": "markdown",
    "id": "8c47985e-ebfb-45da-a66b-846a547d5700",
    "metadata": {
-    "name": "cell13"
+    "name": "cell13",
+    "collapsed": false
    },
    "source": [
     "### Grid Search"
@@ -1252,7 +1259,7 @@
      ]
     }
    ],
-   "source": "######### START HPO RUN With Grid Search ##########\n\ntuner = tune.Tuner(\n    train_func=train_func,\n    search_space = {\n        \"n_estimators\": [50, 51],\n        \"max_depth\": [4,5],\n        \"learning_rate\": [0.01, 0.03]\n    },\n    tuner_config=tune.TunerConfig(\n        metric=\"accuracy\",\n        mode=\"max\",\n        search_alg=search_algorithm.GridSearch(),\n        max_concurrent_trials=2,  # (Optional) Maximum number of trials to run concurrently. If not set, defaults to the number of nodes in the cluster.\n        resource_per_trial={\"CPU\": 1},   # (Optional) Pre-configured for reliability; modification is rarely necessary.\n    ),\n)\n\ntuner_results = tuner.run(dataset_map=dataset_map)\n\n\n"
+   "source": "######### START HPO RUN With Grid Search ##########\n\ntuner = tune.Tuner(\n    train_func=train_func,\n    search_space = {\n        \"n_estimators\": [50, 51],\n        \"max_depth\": [4,5],\n        \"learning_rate\": [0.01, 0.03]\n    },\n    tuner_config=tune.TunerConfig(\n        metric=\"accuracy\",\n        mode=\"max\",\n        search_alg=search_algorithm.GridSearch(),\n        max_concurrent_trials=2,  # (Optional) Maximum number of trials to run concurrently. If not set, defaults to the number of nodes in the cluster.\n        resource_per_trial={\"CPU\": 1},   # (Optional) Pre-configured for reliability; modification is rarely necessary.\n    ),\n)\n\ntuner_results = tuner.run(dataset_map=dataset_map)"
   },
   {
    "cell_type": "code",
@@ -1260,7 +1267,8 @@
    "id": "7adfe452-7865-42d8-8fde-7b025f6d9a68",
    "metadata": {
     "name": "cell15",
-    "language": "python"
+    "language": "python",
+    "codeCollapsed": false
    },
    "outputs": [
     {


### PR DESCRIPTION
The HPO example uses put feature columns and labels into two different data connectors. However, when we read from data connectors, the order is not guaranteed so in most cases we map features to wrong labels, resulting in wrong and inconsistent tuning results over time. This PR fixes this issue.