### PR TITLE
Add RL cookbook: medical SOAP note generation with RLAIF on SPCS

### DIFF
--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/eval_models.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/eval_models.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Evaluate multiple models on the medical SOAP note generation task.
+
+Compares RL-trained checkpoints, base HuggingFace models, and frontier models
+via Snowflake Cortex COMPLETE on a holdout test set.
+
+Supported model formats:
+    cortex:<model_name>     — Snowflake Cortex COMPLETE API (no local GPU needed)
+    hf:<model_id>           — HuggingFace model (requires local GPU / submit_eval.py)
+    checkpoint:<stage_path> — RL checkpoint from Snowflake stage (requires GPU)
+
+Usage:
+    # Quick eval with 100 samples on Cortex models
+    SNOWFLAKE_DEFAULT_CONNECTION_NAME=preprod8 python scripts/eval_models.py \
+        --models "cortex:claude-sonnet-4-6,cortex:llama4-maverick" \
+        --num-samples 100
+
+    # Full eval on all 4028 test samples
+    SNOWFLAKE_DEFAULT_CONNECTION_NAME=preprod8 python scripts/eval_models.py \
+        --models "cortex:claude-sonnet-4-6,cortex:llama4-maverick" \
+        --num-samples 4028
+
+    # Specify judge model
+    SNOWFLAKE_DEFAULT_CONNECTION_NAME=preprod8 python scripts/eval_models.py \
+        --models "cortex:llama4-maverick" \
+        --judge-model "llama3.3-70b" \
+        --num-samples 100
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass, field
+
+from snowflake.snowpark import Session
+
+# ---------------------------------------------------------------------------
+# Add project src/ to path so we can import prompt_utils and reward
+# ---------------------------------------------------------------------------
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_SRC_DIR = os.path.join(_SCRIPT_DIR, "..", "src")
+sys.path.insert(0, _SRC_DIR)
+
+from prompt_utils import (
+    JUDGE_SECTION_SYSTEM_PROMPT,
+    SYSTEM_PROMPT,
+    USER_PROMPT_PREFIX,
+    create_section_judge_prompt,
+)
+from reward import SOAP_KEYS, extract_json_from_response, validate_soap_json
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("eval_models")
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+@dataclass
+class SampleResult:
+    """Result for a single test sample."""
+
+    valid_json: bool = False
+    has_soap_keys: bool = False
+    sections_non_empty: dict = field(default_factory=dict)
+    section_pass: dict = field(default_factory=dict)
+    raw_response: str = ""
+    error: str = ""
+
+
+@dataclass
+class ModelResults:
+    """Aggregated results for one model across all samples."""
+
+    model_name: str
+    samples: list = field(default_factory=list)
+    total: int = 0
+
+    @property
+    def valid_json_count(self) -> int:
+        return sum(1 for s in self.samples if s.valid_json)
+
+    def section_pass_count(self, key: str) -> int:
+        return sum(1 for s in self.samples if s.section_pass.get(key, False))
+
+
+# ---------------------------------------------------------------------------
+# Snowflake session helpers
+# ---------------------------------------------------------------------------
+def create_session(args) -> Session:
+    """Create a Snowflake session from CLI args and environment."""
+    connection_name = os.getenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME")
+    builder = Session.builder
+    if connection_name:
+        builder = builder.config("connection_name", connection_name)
+    if args.database:
+        builder = builder.config("database", args.database)
+    if args.schema:
+        builder = builder.config("schema", args.schema)
+    builder = builder.config("role", "SYSADMIN")
+    session = builder.create()
+
+    if args.database:
+        session.sql(f"USE DATABASE {args.database}").collect()
+    if args.schema:
+        session.sql(f"USE SCHEMA {args.schema}").collect()
+
+    return session
+
+
+def load_test_data(session: Session, table: str, num_samples: int) -> list[dict]:
+    """Load test samples from the MEDICAL_SOAP_TEST table."""
+    logger.info(f"Loading {num_samples} samples from {table}...")
+    rows = session.sql(
+        f"SELECT * FROM {table} LIMIT {num_samples}"
+    ).collect()
+
+    samples = []
+    for row in rows:
+        samples.append({
+            "dialogue": row["DIALOGUE"],
+            "S": row["PRED_S"],
+            "O": row["PRED_O"],
+            "A": row["PRED_A"],
+            "P": row["PRED_P"],
+        })
+
+    logger.info(f"Loaded {len(samples)} test samples.")
+    return samples
+
+
+# ---------------------------------------------------------------------------
+# Cortex COMPLETE inference
+# ---------------------------------------------------------------------------
+def _escape_sql_string(s: str) -> str:
+    """Escape single quotes for SQL string literals."""
+    return s.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def call_cortex_complete(
+    session: Session, model_name: str, system_prompt: str, user_prompt: str,
+    temperature: float | None = None,
+) -> str | None:
+    """Call Snowflake Cortex COMPLETE and return the response text.
+
+    Returns None on error.
+    """
+    escaped_system = _escape_sql_string(system_prompt)
+    escaped_user = _escape_sql_string(user_prompt)
+
+    options = {}
+    if temperature is not None:
+        options["temperature"] = temperature
+
+    # Build options string for SQL
+    if options:
+        opts_parts = []
+        for k, v in options.items():
+            if isinstance(v, (int, float)):
+                opts_parts.append(f"'{k}': {v}")
+            else:
+                opts_parts.append(f"'{k}': '{v}'")
+        options_str = ", ".join(opts_parts)
+    else:
+        options_str = ""
+
+    sql = (
+        f"SELECT SNOWFLAKE.CORTEX.COMPLETE(\n"
+        f"    '{model_name}',\n"
+        f"    [\n"
+        f"        {{'role': 'system', 'content': '{escaped_system}'}},\n"
+        f"        {{'role': 'user', 'content': '{escaped_user}'}}\n"
+        f"    ],\n"
+        f"    {{{options_str}}})"
+    )
+
+    try:
+        result = session.sql(sql).collect()
+        if result and len(result) > 0:
+            raw = result[0][0]
+            # Cortex COMPLETE returns a JSON string with "choices"
+            try:
+                resp_json = json.loads(raw)
+                if "choices" in resp_json:
+                    return resp_json["choices"][0].get("messages", resp_json["choices"][0].get("message", ""))
+                # Some models return the text directly
+                return raw
+            except (json.JSONDecodeError, KeyError, IndexError):
+                return raw
+        return None
+    except Exception as e:
+        logger.warning(f"Cortex COMPLETE error for {model_name}: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Judge evaluation via Cortex
+# ---------------------------------------------------------------------------
+def judge_section(
+    session: Session,
+    judge_model: str,
+    dialogue: str,
+    key: str,
+    ground_truth: str,
+    prediction: str,
+) -> bool:
+    """Use LLM judge via Cortex COMPLETE to evaluate a single SOAP section.
+
+    Returns True if the section passes, False otherwise.
+    """
+    judge_user_prompt = create_section_judge_prompt(dialogue, key, ground_truth, prediction)
+
+    response = call_cortex_complete(
+        session, judge_model, JUDGE_SECTION_SYSTEM_PROMPT, judge_user_prompt,
+        temperature=0,
+    )
+
+    if response is None:
+        return False
+
+    parsed = extract_json_from_response(response)
+    if parsed and isinstance(parsed, dict):
+        verdict = parsed.get("verdict", "").lower().strip()
+        return verdict == "pass"
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Model evaluation
+# ---------------------------------------------------------------------------
+def evaluate_cortex_model(
+    session: Session,
+    model_name: str,
+    test_data: list[dict],
+    judge_model: str,
+) -> ModelResults:
+    """Evaluate a Cortex model on the test dataset."""
+    results = ModelResults(model_name=f"cortex:{model_name}", total=len(test_data))
+    logger.info(f"Evaluating cortex:{model_name} on {len(test_data)} samples...")
+
+    for i, sample in enumerate(test_data):
+        if (i + 1) % 100 == 0 or i == 0:
+            logger.info(
+                f"  [{model_name}] Processing sample {i + 1}/{len(test_data)}..."
+            )
+
+        user_prompt = f"{USER_PROMPT_PREFIX}\n\n{sample['dialogue']}"
+        sr = SampleResult()
+
+        # Generate SOAP note
+        response = call_cortex_complete(session, model_name, SYSTEM_PROMPT, user_prompt)
+        if response is None:
+            sr.error = "No response from Cortex COMPLETE"
+            results.samples.append(sr)
+            continue
+
+        sr.raw_response = response
+
+        # Parse and validate JSON
+        parsed = extract_json_from_response(response)
+        if parsed is None:
+            sr.error = "Failed to parse JSON"
+            results.samples.append(sr)
+            continue
+
+        sr.valid_json = True
+
+        if not validate_soap_json(parsed):
+            sr.error = f"Invalid SOAP keys: {list(parsed.keys()) if isinstance(parsed, dict) else 'not a dict'}"
+            results.samples.append(sr)
+            continue
+
+        sr.has_soap_keys = True
+
+        # Check non-empty sections
+        for key in ["S", "O", "A", "P"]:
+            sr.sections_non_empty[key] = bool(
+                parsed.get(key) and len(parsed[key].strip()) > 0
+            )
+
+        # Judge each section
+        for key in ["S", "O", "A", "P"]:
+            pred_text = parsed.get(key, "")
+            gt_text = sample[key]
+
+            try:
+                passed = judge_section(
+                    session, judge_model, sample["dialogue"], key, gt_text, pred_text,
+                )
+                sr.section_pass[key] = passed
+            except Exception as e:
+                logger.warning(
+                    f"  Judge error on sample {i + 1}, section {key}: {e}"
+                )
+                sr.section_pass[key] = False
+
+        results.samples.append(sr)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+def print_comparison_table(all_results: list[ModelResults], num_samples: int):
+    """Print a formatted comparison table of all model results."""
+    if not all_results:
+        print("No results to display.")
+        return
+
+    # Determine column widths
+    model_names = [r.model_name for r in all_results]
+    col_width = max(max(len(n) for n in model_names), 20)
+    metric_width = 20
+
+    def fmt_count(count: int, total: int) -> str:
+        pct = (count / total * 100) if total > 0 else 0
+        return f"{count} / {total} ({pct:.2f}%)"
+
+    # Header
+    header = f"| {'Metric':<{metric_width}} |"
+    separator = f"|{'-' * (metric_width + 2)}|"
+    for name in model_names:
+        header += f" {name:^{col_width}} |"
+        separator += f"{'-' * (col_width + 2)}|"
+
+    print()
+    print("=" * len(separator))
+    print("EVALUATION RESULTS")
+    print("=" * len(separator))
+    print(header)
+    print(separator)
+
+    # Section pass rates
+    for key, label in [
+        ("S", "S (Subjective)"),
+        ("O", "O (Objective)"),
+        ("A", "A (Assessment)"),
+        ("P", "P (Plan)"),
+    ]:
+        row = f"| {label:<{metric_width}} |"
+        for r in all_results:
+            count = r.section_pass_count(key)
+            row += f" {fmt_count(count, r.total):^{col_width}} |"
+        print(row)
+
+    # Valid JSON
+    row = f"| {'Valid JSON':<{metric_width}} |"
+    for r in all_results:
+        row += f" {fmt_count(r.valid_json_count, r.total):^{col_width}} |"
+    print(row)
+
+    print(separator)
+    print()
+
+
+def write_results_json(all_results: list[ModelResults], output_path: str):
+    """Write detailed results to a JSON file."""
+    output = {}
+    for r in all_results:
+        model_data = {
+            "total_samples": r.total,
+            "valid_json": r.valid_json_count,
+            "section_pass": {
+                key: r.section_pass_count(key) for key in ["S", "O", "A", "P"]
+            },
+            "section_pass_pct": {
+                key: round(r.section_pass_count(key) / r.total * 100, 2)
+                if r.total > 0
+                else 0
+                for key in ["S", "O", "A", "P"]
+            },
+        }
+        output[r.model_name] = model_data
+
+    with open(output_path, "w") as f:
+        json.dump(output, f, indent=2)
+
+    logger.info(f"Results written to {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(
+        description="Evaluate models on medical SOAP note generation",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--models",
+        required=True,
+        help=(
+            "Comma-separated list of models to evaluate. Formats:\n"
+            "  cortex:<name>       — Snowflake Cortex COMPLETE\n"
+            "  hf:<model_id>      — HuggingFace model (local GPU)\n"
+            "  checkpoint:<stage>  — RL checkpoint from Snowflake stage"
+        ),
+    )
+    parser.add_argument(
+        "--num-samples",
+        type=int,
+        default=100,
+        help="Number of test samples to evaluate (default: 100, full: 4028)",
+    )
+    parser.add_argument(
+        "--judge-model",
+        default="llama3.3-70b",
+        help="Cortex model for LLM-as-judge evaluation (default: llama3.3-70b)",
+    )
+    parser.add_argument("--database", default="RL_TRAINING_DB")
+    parser.add_argument("--schema", default="RL_SCHEMA")
+    parser.add_argument(
+        "--test-table", default="MEDICAL_SOAP_TEST",
+        help="Snowflake table with test data (default: MEDICAL_SOAP_TEST)",
+    )
+    parser.add_argument(
+        "--output",
+        default=None,
+        help="Output JSON file for detailed results (optional)",
+    )
+    args = parser.parse_args()
+
+    # Parse model list
+    model_specs = [m.strip() for m in args.models.split(",") if m.strip()]
+    if not model_specs:
+        parser.error("No models specified. Use --models 'cortex:claude-sonnet-4-6,...'")
+
+    cortex_models = []
+    local_models = []
+    for spec in model_specs:
+        if spec.startswith("cortex:"):
+            cortex_models.append(spec.split(":", 1)[1])
+        elif spec.startswith("hf:") or spec.startswith("checkpoint:"):
+            local_models.append(spec)
+        else:
+            parser.error(
+                f"Unknown model format: {spec}. "
+                "Use cortex:<name>, hf:<model_id>, or checkpoint:<stage_path>"
+            )
+
+    # Warn about local models
+    if local_models:
+        print()
+        print("NOTE: The following models require local GPU inference:")
+        for m in local_models:
+            print(f"  - {m}")
+        print("Use scripts/submit_eval.py to run these on SPCS.")
+        print("Only Cortex models will be evaluated in this run.")
+        print()
+
+    if not cortex_models:
+        print("No Cortex models to evaluate. Exiting.")
+        sys.exit(0)
+
+    # Create session and load data
+    session = create_session(args)
+    test_data = load_test_data(session, args.test_table, args.num_samples)
+
+    if not test_data:
+        logger.error("No test data loaded. Check table name and connection.")
+        sys.exit(1)
+
+    # Evaluate each Cortex model
+    all_results: list[ModelResults] = []
+    total_start = time.time()
+
+    for model_name in cortex_models:
+        start = time.time()
+        results = evaluate_cortex_model(
+            session, model_name, test_data, args.judge_model,
+        )
+        elapsed = time.time() - start
+        logger.info(
+            f"Finished {model_name}: {elapsed:.1f}s "
+            f"({elapsed / len(test_data):.2f}s/sample)"
+        )
+        all_results.append(results)
+
+    total_elapsed = time.time() - total_start
+    logger.info(f"Total evaluation time: {total_elapsed:.1f}s")
+
+    # Print comparison table
+    print_comparison_table(all_results, len(test_data))
+
+    # Write JSON output if requested
+    if args.output:
+        write_results_json(all_results, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/prepare_data.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/prepare_data.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Upload medical SOAP training data to Snowflake tables.
+
+Usage:
+    SNOWFLAKE_DEFAULT_CONNECTION_NAME=preprod8 python scripts/prepare_data.py \
+        --data-dir /code/users/thonguyen/sf-samples/samples/ml/ml_jobs/rl_finetune/data
+"""
+import argparse
+import json
+import os
+
+import pandas as pd
+from snowflake.snowpark import Session
+
+
+def upload_json_to_table(session, json_path, table_name, database=None, schema=None):
+    """Upload a JSON file to a Snowflake table."""
+    with open(json_path) as f:
+        data = json.load(f)
+
+    print(f"  Loaded {len(data)} records from {json_path}")
+    print(f"  Keys: {list(data[0].keys())}")
+
+    df = pd.DataFrame(data)
+    # Uppercase column names for Snowflake
+    df.columns = [c.upper() for c in df.columns]
+
+    print(f"  Uploading to {table_name}...")
+    session.write_pandas(
+        df,
+        table_name,
+        auto_create_table=True,
+        overwrite=True,
+        database=database,
+        schema=schema,
+    )
+    print(f"  Uploaded {len(df)} rows to {table_name}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Upload medical SOAP data to Snowflake")
+    parser.add_argument(
+        "--data-dir",
+        default="/code/users/thonguyen/sf-samples/samples/ml/ml_jobs/rl_finetune/data",
+        help="Directory containing synthetic_train_data.json and synthetic_test_data.json",
+    )
+    parser.add_argument("--database", default="RL_TRAINING_DB")
+    parser.add_argument("--schema", default="RL_SCHEMA")
+    parser.add_argument("--train-table", default="MEDICAL_SOAP_TRAIN")
+    parser.add_argument("--test-table", default="MEDICAL_SOAP_TEST")
+    args = parser.parse_args()
+
+    connection_name = os.getenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME")
+    builder = Session.builder
+    if connection_name:
+        builder = builder.config("connection_name", connection_name)
+    if args.database:
+        builder = builder.config("database", args.database)
+    if args.schema:
+        builder = builder.config("schema", args.schema)
+    builder = builder.config("role", "SYSADMIN")
+    session = builder.create()
+
+    if args.database:
+        session.sql(f"USE DATABASE {args.database}").collect()
+    if args.schema:
+        session.sql(f"USE SCHEMA {args.schema}").collect()
+
+    print("Uploading medical SOAP training data...")
+
+    train_path = os.path.join(args.data_dir, "synthetic_train_data.json")
+    test_path = os.path.join(args.data_dir, "synthetic_test_data.json")
+
+    upload_json_to_table(session, train_path, args.train_table, args.database, args.schema)
+    upload_json_to_table(session, test_path, args.test_table, args.database, args.schema)
+
+    # Verify
+    for table in [args.train_table, args.test_table]:
+        result = session.sql(f"SELECT COUNT(*) FROM {table}").collect()
+        print(f"  {table}: {result[0][0]} rows")
+
+    print("Done.")

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/submit_eval.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/submit_eval.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Submit medical SOAP evaluation job using SPCS managed runtime image.
+
+Usage:
+    SNOWFLAKE_DEFAULT_CONNECTION_NAME=preprod8 python scripts/submit_eval.py \
+        --models "cortex:claude-sonnet-4-6,hf:Qwen/Qwen3-1.7B" \
+        --num-samples 100 \
+        --no-wait
+"""
+import argparse
+import os
+
+from snowflake.snowpark import Session
+from snowflake.ml import jobs
+
+PAYLOAD_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
+RUNTIME_IMAGE_TAG = "2.4.1-thong-pytorch-29"
+
+
+def _load_pip_requirements(payload_dir):
+    """Read pip requirements from src/requirements.txt."""
+    req_file = os.path.join(payload_dir, "requirements.txt")
+    reqs = []
+    with open(req_file) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                reqs.append(line)
+    return reqs
+
+
+def submit_eval_job(
+    session: Session,
+    payload_dir: str,
+    compute_pool: str,
+    external_access_integrations: list,
+    models: str,
+    num_samples: int = 100,
+    checkpoint_path: str = "",
+    database: str = None,
+    schema: str = None,
+    stage_name: str = "rl_payload_stage",
+) -> jobs.MLJob:
+    """Submit medical SOAP evaluation job."""
+    spec_overrides = {
+        "spec": {
+            "containers": [
+                {
+                    "name": "main",
+                    "resources": {
+                        "requests": {"nvidia.com/gpu": 4, "memory": "80Gi"},
+                        "limits": {"nvidia.com/gpu": 4, "memory": "160Gi"},
+                    },
+                }
+            ],
+            "volumes": [
+                {"name": "dev-shm", "source": "memory", "size": "16Gi"},
+            ],
+        }
+    }
+
+    env_vars = {
+        "HF_HOME": "/tmp/hf_local",
+        "TRANSFORMERS_CACHE": "/tmp/hf_local",
+        "HUGGINGFACE_HUB_CACHE": "/tmp/hf_local",
+        "HF_HUB_DISABLE_XET": "1",
+        "PYTHONUNBUFFERED": "1",
+        "EVAL_MODELS": models,
+        "NUM_SAMPLES": str(num_samples),
+    }
+
+    if checkpoint_path:
+        env_vars["CHECKPOINT_STAGE_PATH"] = checkpoint_path
+
+    pip_requirements = _load_pip_requirements(payload_dir)
+
+    return jobs.submit_directory(
+        payload_dir,
+        entrypoint=["python", "eval_medical_soap.py"],
+        compute_pool=compute_pool,
+        external_access_integrations=external_access_integrations,
+        env_vars=env_vars,
+        pip_requirements=pip_requirements,
+        runtime_environment=RUNTIME_IMAGE_TAG,
+        spec_overrides=spec_overrides,
+        stage_name=f"{database}.{schema}.{stage_name}" if database and schema else stage_name,
+        database=database,
+        schema=schema,
+        session=session,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Submit medical SOAP evaluation job")
+    parser.add_argument(
+        "--models", required=True,
+        help="Comma-separated model specs, e.g. 'cortex:claude-sonnet-4-6,hf:Qwen/Qwen3-1.7B'",
+    )
+    parser.add_argument("--num-samples", type=int, default=100, help="Number of test samples")
+    parser.add_argument("--checkpoint-path", default="", help="Stage path for checkpoint model")
+    parser.add_argument(
+        "-p", "--compute-pool", default="RL_EVAL_A10_POOL", help="GPU compute pool",
+    )
+    parser.add_argument("--database", default="RL_TRAINING_DB")
+    parser.add_argument("--schema", default="RL_SCHEMA")
+    parser.add_argument("--stage-name", default="rl_payload_stage")
+    parser.add_argument(
+        "-e", "--external-access-integrations",
+        nargs="+",
+        default=["RL_TRAINING_EAI", "ALLOW_ALL_INTEGRATION"],
+    )
+    parser.add_argument("--no-wait", action="store_true", help="Submit and exit")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    connection_name = os.getenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME")
+    builder = Session.builder
+    if connection_name:
+        builder = builder.config("connection_name", connection_name)
+    if args.database:
+        builder = builder.config("database", args.database)
+    if args.schema:
+        builder = builder.config("schema", args.schema)
+    builder = builder.config("role", "SYSADMIN")
+    session = builder.create()
+
+    if args.database:
+        session.sql(f"USE DATABASE {args.database}").collect()
+    if args.schema:
+        session.sql(f"USE SCHEMA {args.schema}").collect()
+
+    pip_reqs = _load_pip_requirements(PAYLOAD_DIR)
+    print(f"Submitting medical SOAP evaluation job (SPCS runtime)...")
+    print(f"  Payload dir: {PAYLOAD_DIR}")
+    print(f"  Models: {args.models}")
+    print(f"  Num samples: {args.num_samples}")
+    print(f"  Compute pool: {args.compute_pool}")
+    print(f"  Runtime image: {RUNTIME_IMAGE_TAG}")
+    print(f"  Pip requirements: {len(pip_reqs)} packages")
+    if args.checkpoint_path:
+        print(f"  Checkpoint path: {args.checkpoint_path}")
+
+    job = submit_eval_job(
+        session=session,
+        payload_dir=PAYLOAD_DIR,
+        compute_pool=args.compute_pool,
+        external_access_integrations=args.external_access_integrations,
+        models=args.models,
+        num_samples=args.num_samples,
+        checkpoint_path=args.checkpoint_path,
+        database=args.database,
+        schema=args.schema,
+        stage_name=args.stage_name,
+    )
+
+    print(f"Job submitted: {job.id}")
+
+    if args.no_wait:
+        print("--no-wait: job running in background.")
+    else:
+        print("Waiting for job to complete...")
+        status = job.wait()
+        print(f"Job finished with status: {status}")
+        if args.verbose:
+            print(f"\nLogs:\n{job.get_logs()}")

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/submit_eval.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/submit_eval.py
@@ -37,24 +37,29 @@ def submit_eval_job(
     models: str,
     num_samples: int = 100,
     checkpoint_path: str = "",
+    num_gpus: int = 4,
     database: str = None,
     schema: str = None,
     stage_name: str = "rl_payload_stage",
 ) -> jobs.MLJob:
     """Submit medical SOAP evaluation job."""
+    memory_req = f"{num_gpus * 20}Gi"
+    memory_lim = f"{num_gpus * 40}Gi"
+    shm_size = f"{max(16, num_gpus * 4)}Gi"
+
     spec_overrides = {
         "spec": {
             "containers": [
                 {
                     "name": "main",
                     "resources": {
-                        "requests": {"nvidia.com/gpu": 4, "memory": "80Gi"},
-                        "limits": {"nvidia.com/gpu": 4, "memory": "160Gi"},
+                        "requests": {"nvidia.com/gpu": num_gpus, "memory": memory_req},
+                        "limits": {"nvidia.com/gpu": num_gpus, "memory": memory_lim},
                     },
                 }
             ],
             "volumes": [
-                {"name": "dev-shm", "source": "memory", "size": "16Gi"},
+                {"name": "dev-shm", "source": "memory", "size": shm_size},
             ],
         }
     }
@@ -101,6 +106,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-p", "--compute-pool", default="RL_EVAL_A10_POOL", help="GPU compute pool",
     )
+    parser.add_argument("--num-gpus", type=int, default=4, help="Number of GPUs to request")
     parser.add_argument("--database", default="RL_TRAINING_DB")
     parser.add_argument("--schema", default="RL_SCHEMA")
     parser.add_argument("--stage-name", default="rl_payload_stage")
@@ -135,6 +141,7 @@ if __name__ == "__main__":
     print(f"  Models: {args.models}")
     print(f"  Num samples: {args.num_samples}")
     print(f"  Compute pool: {args.compute_pool}")
+    print(f"  Num GPUs: {args.num_gpus}")
     print(f"  Runtime image: {RUNTIME_IMAGE_TAG}")
     print(f"  Pip requirements: {len(pip_reqs)} packages")
     if args.checkpoint_path:
@@ -148,6 +155,7 @@ if __name__ == "__main__":
         models=args.models,
         num_samples=args.num_samples,
         checkpoint_path=args.checkpoint_path,
+        num_gpus=args.num_gpus,
         database=args.database,
         schema=args.schema,
         stage_name=args.stage_name,

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/submit_train.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/scripts/submit_train.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Submit medical SOAP RL training using SPCS managed runtime image.
+
+Usage:
+    SNOWFLAKE_DEFAULT_CONNECTION_NAME=preprod8 python scripts/submit_train.py --no-wait
+"""
+import argparse
+import os
+
+from snowflake.snowpark import Session
+from snowflake.ml import jobs
+
+PAYLOAD_DIR = os.path.join(os.path.dirname(__file__), "..", "src")
+RUNTIME_IMAGE_TAG = "2.4.1-thong-pytorch-29"
+
+
+def _load_pip_requirements(payload_dir):
+    """Read pip requirements from src/requirements.txt."""
+    req_file = os.path.join(payload_dir, "requirements.txt")
+    reqs = []
+    with open(req_file) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                reqs.append(line)
+    return reqs
+
+
+def submit_training_job(
+    session: Session,
+    payload_dir: str,
+    config: str,
+    compute_pool: str,
+    external_access_integrations: list,
+    database: str = None,
+    schema: str = None,
+    stage_name: str = "rl_payload_stage",
+) -> jobs.MLJob:
+    """Submit medical SOAP RL training job."""
+    config_path = os.path.join(payload_dir, config)
+    if not os.path.isfile(config_path):
+        raise FileNotFoundError(f"Config file not found: {config_path}")
+
+    spec_overrides = {
+        "spec": {
+            "containers": [
+                {
+                    "name": "main",
+                    "resources": {
+                        "requests": {"nvidia.com/gpu": 8, "memory": "160Gi"},
+                        "limits": {"nvidia.com/gpu": 8, "memory": "320Gi"},
+                    },
+                    "secrets": [
+                        {
+                            "snowflakeSecret": {
+                                "objectName": "rl_training_db.rl_schema.wandb_api_key_secret",
+                            },
+                            "secretKeyRef": "secret_string",
+                            "envVarName": "WANDB_API_KEY",
+                        }
+                    ],
+                }
+            ],
+            "volumes": [
+                {"name": "dev-shm", "source": "memory", "size": "96Gi"},
+            ],
+        }
+    }
+
+    env_vars = {
+        "HF_HOME": "/tmp/hf_local",
+        "TRANSFORMERS_CACHE": "/tmp/hf_local",
+        "HUGGINGFACE_HUB_CACHE": "/tmp/hf_local",
+        "HF_HUB_DISABLE_XET": "1",
+        "WANDB_BASE_URL": "https://snowflake.wandb.io",
+        "PYTHONUNBUFFERED": "1",
+        # Local vLLM judge configuration (2 judges on GPUs 6-7)
+        "LOCAL_JUDGE_MODEL": "Qwen/Qwen3-8B",
+        "LOCAL_JUDGE_PORTS": "38899,38900",
+        "LOCAL_JUDGE_BASE_PORT": "38899",
+    }
+
+    pip_requirements = _load_pip_requirements(payload_dir)
+
+    return jobs.submit_directory(
+        payload_dir,
+        entrypoint=["python", "run_medical_soap.py", "--config", config],
+        compute_pool=compute_pool,
+        external_access_integrations=external_access_integrations,
+        env_vars=env_vars,
+        pip_requirements=pip_requirements,
+        runtime_environment=RUNTIME_IMAGE_TAG,
+        spec_overrides=spec_overrides,
+        stage_name=f"{database}.{schema}.{stage_name}" if database and schema else stage_name,
+        database=database,
+        schema=schema,
+        session=session,
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Submit medical SOAP RL training")
+    parser.add_argument(
+        "-p", "--compute-pool", default="RL_LOCAL_JUDGE_POOL", help="GPU compute pool"
+    )
+    parser.add_argument("--database", default="RL_TRAINING_DB")
+    parser.add_argument("--schema", default="RL_SCHEMA")
+    parser.add_argument("--stage-name", default="rl_payload_stage")
+    parser.add_argument(
+        "-e", "--external-access-integrations",
+        nargs="+",
+        default=["RL_TRAINING_EAI", "ALLOW_ALL_INTEGRATION"],
+    )
+    parser.add_argument("-c", "--config", default="config.yaml")
+    parser.add_argument("--no-wait", action="store_true", help="Submit and exit")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    connection_name = os.getenv("SNOWFLAKE_DEFAULT_CONNECTION_NAME")
+    builder = Session.builder
+    if connection_name:
+        builder = builder.config("connection_name", connection_name)
+    if args.database:
+        builder = builder.config("database", args.database)
+    if args.schema:
+        builder = builder.config("schema", args.schema)
+    builder = builder.config("role", "SYSADMIN")
+    session = builder.create()
+
+    if args.database:
+        session.sql(f"USE DATABASE {args.database}").collect()
+    if args.schema:
+        session.sql(f"USE SCHEMA {args.schema}").collect()
+
+    pip_reqs = _load_pip_requirements(PAYLOAD_DIR)
+    print(f"Submitting medical SOAP RL training (SPCS runtime)...")
+    print(f"  Payload dir: {PAYLOAD_DIR}")
+    print(f"  Config: {args.config}")
+    print(f"  Compute pool: {args.compute_pool}")
+    print(f"  Runtime image: {RUNTIME_IMAGE_TAG}")
+    print(f"  Pip requirements: {len(pip_reqs)} packages")
+
+    job = submit_training_job(
+        session=session,
+        payload_dir=PAYLOAD_DIR,
+        config=args.config,
+        compute_pool=args.compute_pool,
+        external_access_integrations=args.external_access_integrations,
+        database=args.database,
+        schema=args.schema,
+        stage_name=args.stage_name,
+    )
+
+    print(f"Job submitted: {job.id}")
+
+    if args.no_wait:
+        print("--no-wait: job running in background.")
+    else:
+        print("Waiting for job to complete...")
+        status = job.wait()
+        print(f"Job finished with status: {status}")
+        if args.verbose:
+            print(f"\nLogs:\n{job.get_logs()}")

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/config.yaml
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/config.yaml
@@ -1,0 +1,182 @@
+# Medical SOAP RL Training — SPCS Runtime Image
+#
+# Trains Qwen3-1.7B to generate SOAP notes from doctor-patient dialogues.
+# Reward: format check (1pt) + per-section LLM judge (4pts) = max 5.0
+#
+# GPU layout (8x A100):
+#   GPUs 0-5: AReaL (2 vLLM rollout dp=2 + 4 FSDP training dp=4)
+#   GPUs 6-7: 2x vLLM judge servers (Qwen3-8B)
+
+experiment_name: medical-soap-rl
+trial_name: spcs_v5
+
+seed: 1
+enable_offload: false
+total_train_epochs: 10
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 1
+  n_gpus_per_node: 8
+  fileroot: /tmp/areal_medical_soap_${trial_name}
+  name_resolve:
+    type: ray
+    ray_actor_name: areal_kv_store
+
+# 6 GPUs for AReaL: 2 rollout (dp=2, tp=1) + 4 training (dp=4)
+allocation_mode: vllm:d2p1t1+d4p1t1
+
+scheduler:
+  type: ray
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 32
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 4
+  enable_rollout_tracing: false
+  scheduling_spec: ${actor.scheduling_spec}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  dump_to_file: true
+  setup_timeout: 600.0
+  request_timeout: 600.0
+  pause_grace_period: 1.0
+  use_lora: false
+
+gconfig:
+  n_samples: 4
+  min_new_tokens: 0
+  max_new_tokens: 1024
+  greedy: false
+  temperature: 1.0
+
+# Actor (policy model) — Qwen3-1.7B full weight training
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3-1.7B
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: true
+  dtype: bfloat16
+  attn_impl: flash_attention_2
+  mb_spec:
+    max_tokens_per_mb: 8192
+  optimizer:
+    type: adam
+    lr: 3e-6
+    weight_decay: 0.01
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  eps_clip: 0.4
+  eps_clip_higher: 0.5
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.05
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - cpu: 4
+      gpu: 1
+      mem: 10
+  use_lora: false
+  weight_update_mode: xccl
+
+# Reference model (for KL penalty — kl_ctl=0 so effectively unused but required)
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  attn_impl: flash_attention_2
+  mb_spec:
+    max_tokens_per_mb: 8192
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+# vLLM inference server (for rollout generation, NOT judging)
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: false
+  dtype: ${actor.dtype}
+  max_model_len: 6144
+  gpu_memory_utilization: 0.85
+
+# Datasets — loaded from Snowflake tables at runtime
+train_dataset:
+  batch_size: 128
+  shuffle: true
+  pin_memory: true
+  num_workers: 2
+  path: MEDICAL_SOAP_TRAIN
+  type: rl
+  max_length: 3072
+
+valid_dataset:
+  batch_size: 32
+  pin_memory: true
+  num_workers: 2
+  path: MEDICAL_SOAP_TEST
+  type: rl
+
+# Checkpointing — save directly to stage mount so checkpoints are accessible externally
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: /mnt/job_stage/output/model_output_${trial_name}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: "off"
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+# Logging
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: online
+    project: spcs-medical-soap-rl
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/config.yaml
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/config.yaml
@@ -8,7 +8,7 @@
 #   GPUs 6-7: 2x vLLM judge servers (Qwen3-8B)
 
 experiment_name: medical-soap-rl
-trial_name: spcs_v5
+trial_name: spcs_v6
 
 seed: 1
 enable_offload: false

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/config_lora.yaml
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/config_lora.yaml
@@ -1,0 +1,190 @@
+# Medical SOAP RL Training — LoRA with disk-based weight sync
+#
+# Replicates the original soap_grpo_lora.yaml parameters on SPCS.
+# Uses LoRA (rank=16, alpha=32) with disk-based weight sync.
+#
+# GPU layout (8x A100):
+#   GPUs 0-5: AReaL (2 vLLM rollout dp=2 + 4 FSDP training dp=4)
+#   GPUs 6-7: 2x vLLM judge servers (Qwen3-8B)
+
+experiment_name: medical-soap-rl-lora
+trial_name: spcs_v1
+
+seed: 1
+enable_offload: false
+total_train_epochs: 10
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 1
+  n_gpus_per_node: 8
+  fileroot: /tmp/areal_medical_soap_lora_${trial_name}
+  name_resolve:
+    type: ray
+    ray_actor_name: areal_kv_store
+
+# 6 GPUs for AReaL: 2 rollout (dp=2, tp=1) + 4 training (dp=4)
+allocation_mode: vllm:d2p1t1+d4p1t1
+
+scheduler:
+  type: ray
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 256
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 4
+  enable_rollout_tracing: false
+  scheduling_spec: ${actor.scheduling_spec}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  dump_to_file: true
+  setup_timeout: 600.0
+  request_timeout: 600.0
+  pause_grace_period: 1.0
+  use_lora: true
+
+gconfig:
+  n_samples: 4
+  min_new_tokens: 0
+  max_new_tokens: 1024
+  greedy: false
+  temperature: 1.0
+
+# Actor — LoRA training (replicating original soap_grpo_lora.yaml)
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3-1.7B
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: true
+  dtype: bfloat16
+  attn_impl: flash_attention_2
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer:
+    type: adam
+    lr: 3e-5
+    weight_decay: 0.01
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  eps_clip: 0.4
+  eps_clip_higher: 0.5
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - cpu: 4
+      gpu: 1
+      mem: 10
+  # LoRA config
+  use_lora: true
+  peft_type: lora
+  lora_rank: 16
+  lora_alpha: 32
+  target_modules: [all-linear]
+  weight_update_mode: xccl
+
+# Reference model (colocated with actor)
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  attn_impl: flash_attention_2
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+# vLLM inference server (for rollout generation)
+vllm:
+  model: ${actor.path}
+  seed: ${seed}
+  skip_tokenizer_init: false
+  dtype: ${actor.dtype}
+  max_model_len: 6144
+  gpu_memory_utilization: 0.6
+  # LoRA support
+  enable_lora: true
+  max_lora_rank: ${actor.lora_rank}
+
+# Datasets — loaded from Snowflake tables at runtime
+train_dataset:
+  batch_size: 12
+  shuffle: true
+  pin_memory: true
+  num_workers: 2
+  path: MEDICAL_SOAP_TRAIN
+  type: rl
+  max_length: 2048
+
+valid_dataset:
+  batch_size: 16
+  pin_memory: true
+  num_workers: 2
+  path: MEDICAL_SOAP_TEST
+  type: rl
+
+# Checkpointing — save directly to stage mount
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: /mnt/job_stage/output/model_output_lora_${trial_name}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: "off"
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+# Logging
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: online
+    project: spcs-medical-soap-rl
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/config_lora_sglang.yaml
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/config_lora_sglang.yaml
@@ -1,0 +1,196 @@
+# Medical SOAP RL Training — LoRA with SGLang rollout + disk weight sync
+#
+# Uses SGLang (not vLLM) for rollout with LoRA support.
+# vLLM + LoRA has a bug where adapter names aren't registered after weight
+# updates, causing generation to fail. SGLang handles adapter reloading correctly.
+#
+# GPU layout (8x A100):
+#   GPUs 0-4: AReaL (4 SGLang rollout dp=4 + 1 training dp=1, no FSDP2)
+#   GPUs 5-7: 3x vLLM judge servers (Qwen3-8B)
+
+experiment_name: medical-soap-rl-lora
+trial_name: spcs_sglang_v6
+
+seed: 1
+enable_offload: false
+total_train_epochs: 10
+tokenizer_path: ${actor.path}
+
+cluster:
+  n_nodes: 1
+  n_gpus_per_node: 8
+  fileroot: /tmp/areal_medical_soap_lora_sglang_${trial_name}
+  name_resolve:
+    type: ray
+    ray_actor_name: areal_kv_store
+
+# 5 GPUs for AReaL: 4 SGLang rollout (dp=4, tp=1) + 1 training (dp=1, no FSDP2)
+allocation_mode: sglang:d4p1t1+d1p1t1
+
+scheduler:
+  type: ray
+
+rollout:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  max_concurrent_rollouts: 256
+  queue_size: null
+  consumer_batch_size: ${train_dataset.batch_size}
+  max_head_offpolicyness: 4
+  enable_rollout_tracing: false
+  scheduling_spec: ${actor.scheduling_spec}
+  fileroot: ${cluster.fileroot}
+  tokenizer_path: ${tokenizer_path}
+  dump_to_file: true
+  setup_timeout: 600.0
+  request_timeout: 600.0
+  pause_grace_period: 1.0
+  use_lora: true
+
+gconfig:
+  n_samples: 4
+  min_new_tokens: 0
+  max_new_tokens: 1024
+  greedy: false
+  temperature: 1.0
+  lora_name: ${experiment_name}
+
+# Actor — LoRA training (replicating original soap_grpo_lora.yaml)
+actor:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: Qwen/Qwen3-1.7B
+  init_from_scratch: false
+  disable_dropout: true
+  gradient_checkpointing: true
+  dtype: bfloat16
+  attn_impl: flash_attention_2
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer:
+    type: adam
+    lr: 3e-5
+    weight_decay: 0.01
+    beta1: 0.9
+    beta2: 0.999
+    eps: 1e-8
+    lr_scheduler_type: constant
+    gradient_clipping: 1.0
+    warmup_steps_proportion: 0.001
+  eps_clip: 0.4
+  eps_clip_higher: 0.5
+  temperature: ${gconfig.temperature}
+  reward_scaling: 10.0
+  reward_bias: -0.5
+  kl_ctl: 0.0
+  ppo_n_minibatches: 1
+  recompute_logprob: true
+  use_decoupled_loss: true
+  reward_norm:
+    mean_level: group
+    std_level: group
+    group_size: ${gconfig.n_samples}
+  adv_norm:
+    mean_level: batch
+    std_level: batch
+  max_new_tokens: ${gconfig.max_new_tokens}
+  scheduling_spec:
+    - cpu: 4
+      gpu: 1
+      mem: 10
+  # LoRA config
+  use_lora: true
+  peft_type: lora
+  lora_rank: 16
+  lora_alpha: 32
+  target_modules: [all-linear]
+  weight_update_mode: disk
+
+# Reference model (colocated with actor)
+ref:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  path: ${actor.path}
+  disable_dropout: true
+  dtype: ${actor.dtype}
+  attn_impl: flash_attention_2
+  mb_spec:
+    max_tokens_per_mb: 10240
+  optimizer: null
+  scheduling_strategy:
+    type: colocation
+    target: actor
+  scheduling_spec: ${actor.scheduling_spec}
+
+# SGLang inference server (for rollout generation with LoRA)
+sglang:
+  model_path: ${actor.path}
+  random_seed: ${seed}
+  skip_tokenizer_init: true
+  dtype: ${actor.dtype}
+  max_running_requests: null
+  context_length: 6144
+  mem_fraction_static: 0.8
+  # LoRA support
+  enable_lora: ${actor.use_lora}
+  max_lora_rank: ${actor.lora_rank}
+  lora_target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+  lora_backend: csgmv
+  schedule_policy: fcfs
+
+# Datasets — loaded from Snowflake tables at runtime
+train_dataset:
+  batch_size: 12
+  shuffle: true
+  pin_memory: true
+  num_workers: 2
+  path: MEDICAL_SOAP_TRAIN
+  type: rl
+  max_length: 2048
+
+valid_dataset:
+  batch_size: 16
+  pin_memory: true
+  num_workers: 2
+  path: MEDICAL_SOAP_TEST
+  type: rl
+
+# Checkpointing — save to stage mount (Fix 6 bypasses FSDP2 for LoRA)
+saver:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: /mnt/job_stage/output/model_output_lora_sglang_${trial_name}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+recover:
+  mode: "off"
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+evaluator:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  freq_epochs: 1
+  freq_steps: null
+  freq_secs: null
+
+# Logging
+stats_logger:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}
+  wandb:
+    mode: online
+    project: spcs-medical-soap-rl
+
+perf_tracer:
+  experiment_name: ${experiment_name}
+  trial_name: ${trial_name}
+  fileroot: ${cluster.fileroot}

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/eval_medical_soap.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/eval_medical_soap.py
@@ -358,17 +358,26 @@ _gen_port = 38900
 _gen_model_name = None
 
 
-def start_gen_server(model_path):
-    """Start a vLLM server on GPU 0 for generating completions."""
+def start_gen_server(model_path, tp=1, gpu_ids=None):
+    """Start a vLLM server for generating completions.
+    
+    Args:
+        model_path: HuggingFace model name or local path
+        tp: tensor parallel size (e.g. 8 for 235B model)
+        gpu_ids: comma-separated GPU IDs (e.g. "0,1,2,3,4,5,6,7"), defaults to GEN_GPU
+    """
     global _gen_process, _gen_model_name
 
     # Kill any existing gen server
     stop_gen_server()
 
-    print(f"\n--- Starting vLLM Generation Server (GPU {GEN_GPU}, port {_gen_port}) ---")
+    if gpu_ids is None:
+        gpu_ids = str(GEN_GPU)
+
+    print(f"\n--- Starting vLLM Generation Server (GPUs {gpu_ids}, tp={tp}, port {_gen_port}) ---")
     print(f"  Model: {model_path}")
     env = os.environ.copy()
-    env["CUDA_VISIBLE_DEVICES"] = str(GEN_GPU)
+    env["CUDA_VISIBLE_DEVICES"] = gpu_ids
 
     cmd = [
         sys.executable, "-m", "vllm.entrypoints.openai.api_server",
@@ -380,12 +389,14 @@ def start_gen_server(model_path):
         "--trust-remote-code",
         "--disable-log-requests",
     ]
+    if tp > 1:
+        cmd.extend(["--tensor-parallel-size", str(tp)])
 
     _gen_process = subprocess.Popen(cmd, env=env, start_new_session=True)
     _gen_model_name = model_path
 
-    # Wait for server to become healthy
-    max_wait = 600
+    # Wait for server to become healthy (longer timeout for large TP models)
+    max_wait = 1800 if tp > 1 else 600
     start_time = time.time()
     last_log = 0
 
@@ -436,29 +447,53 @@ def stop_gen_server():
 # Model Completion Backends
 # ============================================================================
 def _generate_cortex(model_name, system_prompt, user_prompt, host):
-    """Generate completion via Snowflake Cortex COMPLETE REST API."""
-    # Escape single quotes for SQL
-    sys_escaped = system_prompt.replace("'", "''")
-    user_escaped = user_prompt.replace("'", "''")
+    """Generate completion via Snowflake Cortex COMPLETE SQL API."""
+    messages = json.dumps([
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ])
+    options = json.dumps({"temperature": 0, "max_tokens": 2048})
 
-    sql = (
-        f"SELECT SNOWFLAKE.CORTEX.COMPLETE("
-        f"'{model_name}', "
-        f"PARSE_JSON('[{{\"role\": \"system\", \"content\": ''{sys_escaped}''}},"
-        f"{{\"role\": \"user\", \"content\": ''{user_escaped}''}}]'), "
-        f"PARSE_JSON('{{\"temperature\": 0, \"max_tokens\": 2048}}')"
-        f") AS response"
-    )
+    # Use bindings to avoid SQL injection / escaping issues with medical text
+    url = f"https://{host}/api/v2/statements"
+    payload = {
+        "statement": (
+            "SELECT SNOWFLAKE.CORTEX.COMPLETE(?, PARSE_JSON(?), PARSE_JSON(?)) AS response"
+        ),
+        "bindings": {
+            "1": {"type": "TEXT", "value": model_name},
+            "2": {"type": "TEXT", "value": messages},
+            "3": {"type": "TEXT", "value": options},
+        },
+        "timeout": 180,
+        "resultSetMetaData": {"format": "jsonv2"},
+        "warehouse": os.environ.get("CORTEX_WAREHOUSE", "ADMIN_WH"),
+        "database": DATA_DATABASE,
+        "schema": DATA_SCHEMA,
+    }
+    body = json.dumps(payload).encode("utf-8")
 
-    result = _execute_sql(sql, host)
-    raw = result["data"][0][0]
-    # Cortex COMPLETE returns JSON with "choices" array
+    import ssl
+    ctx = ssl.create_default_context()
+    token = _get_spcs_token()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    req.add_header("Authorization", f"Bearer {token}")
+
+    resp = urllib.request.urlopen(req, context=ctx, timeout=180)
+    raw = resp.read()
+    if raw[:2] == b'\x1f\x8b':
+        import gzip
+        raw = gzip.decompress(raw)
+    result = json.loads(raw.decode("utf-8"))
+
+    raw_text = result["data"][0][0]
     try:
-        parsed = json.loads(raw)
+        parsed = json.loads(raw_text)
         return parsed["choices"][0]["messages"]
     except (json.JSONDecodeError, KeyError, IndexError):
-        # Some versions return plain text
-        return raw
+        return raw_text
 
 
 def _generate_vllm(model_name, system_prompt, user_prompt):
@@ -544,8 +579,7 @@ async def _call_judge_async(session, system_prompt, user_prompt):
             {"role": "user", "content": user_prompt},
         ],
         "temperature": 0.0,
-        "max_tokens": 512,
-        "chat_template_kwargs": {"enable_thinking": False},
+        "max_tokens": 2048,
     }
 
     try:
@@ -643,20 +677,32 @@ async def evaluate_model(model_spec, samples, host):
         create_section_judge_prompt,
     )
 
-    # Parse model spec
+    # Parse model spec — supports "backend:model" or "backend:model:tp=N"
     parts = model_spec.split(":", 1)
     backend = parts[0]
     model_name = parts[1] if len(parts) > 1 else parts[0]
+    tp = 1
+    if ":tp=" in model_spec:
+        # e.g. "hf:Qwen/Qwen3-235B-A22B:tp=8"
+        segments = model_spec.split(":")
+        backend = segments[0]
+        tp_parts = [s for s in segments if s.startswith("tp=")]
+        if tp_parts:
+            tp = int(tp_parts[0].split("=")[1])
+        model_name = ":".join(s for s in segments[1:] if not s.startswith("tp="))
 
-    print(f"\n--- Evaluating: {model_spec} ---")
+    print(f"\n--- Evaluating: {model_spec} (tp={tp}) ---")
+
+    # Determine GPU IDs for this model
+    if tp > 1:
+        gpu_ids = ",".join(str(i) for i in range(_num_gpus))
+    else:
+        gpu_ids = None  # defaults to GEN_GPU
 
     # Start generation server if needed
     if backend in ("hf", "checkpoint"):
         model_path = model_name
-        if backend == "checkpoint":
-            # model_name is the local path (already downloaded)
-            model_path = model_name
-        start_gen_server(model_path)
+        start_gen_server(model_path, tp=tp, gpu_ids=gpu_ids)
 
     # Generate completions
     completions = []
@@ -804,8 +850,16 @@ def main():
     if checkpoint_stage_path:
         print(f"  Checkpoint stage: {checkpoint_stage_path}")
 
-    # 1. Start judge server
-    start_judge_server()
+    # 1. Check if any model needs all GPUs (tp = num_gpus).
+    #    If so, defer judge startup until after generation to avoid GPU conflict.
+    needs_all_gpus = any(
+        f":tp={_num_gpus}" in spec or f":tp= {_num_gpus}" in spec
+        for spec in model_specs
+    )
+    if needs_all_gpus:
+        print(f"  Large model detected (tp={_num_gpus}): deferring judge until after generation")
+    else:
+        start_judge_server()
 
     # 2. Copy reward module to importable location
     REWARD_MODULE_DIR = "/tmp/reward_modules"
@@ -845,19 +899,147 @@ def main():
 
     # 5. Evaluate each model
     all_results = []
-    for spec in model_specs:
-        try:
-            result = asyncio.run(evaluate_model(spec, all_samples, host))
-            all_results.append(result)
-        except Exception as e:
-            import traceback
-            print(f"\n  ERROR evaluating {spec}:")
-            print(traceback.format_exc())
-            all_results.append({
-                "model": spec, "n": len(all_samples), "format_ok": 0,
-                "format_pct": 0, "S": 0, "O": 0, "A": 0, "P": 0,
-                "avg_total": 0, "gen_errors": len(all_samples), "judge_errors": 0,
-            })
+    if needs_all_gpus:
+        # Two-phase: generate all completions first, then judge after starting judge server.
+        # This allows large TP models to use all GPUs during generation.
+        all_completions = {}  # model_spec -> (completions, gen_errors, backend, model_name)
+        for spec in model_specs:
+            try:
+                parts = spec.split(":", 1)
+                backend = parts[0]
+                model_name = parts[1] if len(parts) > 1 else parts[0]
+                tp = 1
+                if ":tp=" in spec:
+                    segments = spec.split(":")
+                    backend = segments[0]
+                    tp_parts = [s for s in segments if s.startswith("tp=")]
+                    if tp_parts:
+                        tp = int(tp_parts[0].split("=")[1])
+                    model_name = ":".join(s for s in segments[1:] if not s.startswith("tp="))
+
+                print(f"\n--- Generating: {spec} (tp={tp}) ---")
+
+                if tp > 1:
+                    gpu_ids = ",".join(str(i) for i in range(_num_gpus))
+                else:
+                    gpu_ids = None
+
+                from medical_soap.prompt_utils import SYSTEM_PROMPT, USER_PROMPT_PREFIX
+
+                completions = []
+                gen_errors = 0
+                if backend in ("hf", "checkpoint"):
+                    start_gen_server(model_name, tp=tp, gpu_ids=gpu_ids)
+                for i, sample in enumerate(all_samples):
+                    user_prompt = f"{USER_PROMPT_PREFIX}\n\n{sample['DIALOGUE']}"
+                    try:
+                        if backend == "cortex":
+                            completion = _generate_cortex(model_name, SYSTEM_PROMPT, user_prompt, host)
+                        elif backend in ("hf", "checkpoint"):
+                            completion = _generate_vllm(_gen_model_name, SYSTEM_PROMPT, user_prompt)
+                        else:
+                            raise ValueError(f"Unknown backend: {backend}")
+                        completions.append(completion)
+                    except Exception as e:
+                        print(f"  [gen error] Sample {i}: {type(e).__name__}: {e}")
+                        completions.append("")
+                        gen_errors += 1
+                    if (i + 1) % 50 == 0:
+                        print(f"  Generated {i + 1}/{len(all_samples)} completions ({gen_errors} errors)")
+                print(f"  Generation complete: {len(completions)} completions, {gen_errors} errors")
+                if backend in ("hf", "checkpoint"):
+                    stop_gen_server()
+                all_completions[spec] = (completions, gen_errors)
+            except Exception as e:
+                import traceback
+                print(f"\n  ERROR generating for {spec}:")
+                print(traceback.format_exc())
+                all_completions[spec] = ([""] * len(all_samples), len(all_samples))
+
+        # Now start judge and score everything
+        print("\n--- Starting Judge for Scoring Phase ---")
+        start_judge_server()
+
+        import aiohttp
+        from medical_soap.prompt_utils import (
+            JUDGE_SECTION_SYSTEM_PROMPT,
+            create_section_judge_prompt,
+        )
+
+        for spec in model_specs:
+            completions, gen_errors = all_completions[spec]
+            print(f"\n--- Judging: {spec} ---")
+            try:
+                async def _judge_completions():
+                    timeout = aiohttp.ClientTimeout(total=120, sock_connect=5, sock_read=120)
+                    async with aiohttp.ClientSession(timeout=timeout) as aio_session:
+                        judge_errors = 0
+                        results = []
+                        batch_size = 20
+                        for batch_start in range(0, len(all_samples), batch_size):
+                            batch_end = min(batch_start + batch_size, len(all_samples))
+                            batch_tasks = []
+                            for j in range(batch_start, batch_end):
+                                if completions[j]:
+                                    batch_tasks.append(
+                                        evaluate_single_sample(
+                                            aio_session, all_samples[j], completions[j],
+                                            JUDGE_SECTION_SYSTEM_PROMPT, create_section_judge_prompt,
+                                        )
+                                    )
+                                else:
+                                    async def _zero():
+                                        return {"format_ok": False, "S": 0.0, "O": 0.0, "A": 0.0, "P": 0.0, "total": 0.0}
+                                    batch_tasks.append(_zero())
+                            batch_results = await asyncio.gather(*batch_tasks, return_exceptions=True)
+                            for r in batch_results:
+                                if isinstance(r, Exception):
+                                    judge_errors += 1
+                                    results.append({"format_ok": False, "S": 0.0, "O": 0.0, "A": 0.0, "P": 0.0, "total": 0.0})
+                                else:
+                                    results.append(r)
+                            if batch_end % 50 == 0 or batch_end == len(all_samples):
+                                print(f"  Judged {batch_end}/{len(all_samples)} samples ({judge_errors} errors)")
+                        return results, judge_errors
+                results, judge_errors = asyncio.run(_judge_completions())
+                n = len(results)
+                all_results.append({
+                    "model": spec,
+                    "n": n,
+                    "format_ok": sum(1 for r in results if r["format_ok"]),
+                    "format_pct": sum(1 for r in results if r["format_ok"]) / n * 100 if n else 0,
+                    "S": sum(r["S"] for r in results) / n if n else 0,
+                    "O": sum(r["O"] for r in results) / n if n else 0,
+                    "A": sum(r["A"] for r in results) / n if n else 0,
+                    "P": sum(r["P"] for r in results) / n if n else 0,
+                    "avg_total": sum(r["total"] for r in results) / n if n else 0,
+                    "gen_errors": gen_errors,
+                    "judge_errors": judge_errors,
+                })
+            except Exception as e:
+                import traceback
+                print(f"\n  ERROR judging {spec}:")
+                print(traceback.format_exc())
+                all_results.append({
+                    "model": spec, "n": len(all_samples), "format_ok": 0,
+                    "format_pct": 0, "S": 0, "O": 0, "A": 0, "P": 0,
+                    "avg_total": 0, "gen_errors": gen_errors, "judge_errors": len(all_samples),
+                })
+    else:
+        # Original flow: judge is already running, evaluate each model end-to-end
+        for spec in model_specs:
+            try:
+                result = asyncio.run(evaluate_model(spec, all_samples, host))
+                all_results.append(result)
+            except Exception as e:
+                import traceback
+                print(f"\n  ERROR evaluating {spec}:")
+                print(traceback.format_exc())
+                all_results.append({
+                    "model": spec, "n": len(all_samples), "format_ok": 0,
+                    "format_pct": 0, "S": 0, "O": 0, "A": 0, "P": 0,
+                    "avg_total": 0, "gen_errors": len(all_samples), "judge_errors": 0,
+                })
 
     # 6. Print comparison table
     print_comparison_table(all_results)

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/eval_medical_soap.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/eval_medical_soap.py
@@ -1,0 +1,906 @@
+#!/usr/bin/env python3
+"""
+Medical SOAP Evaluation: Compare models on SOAP note generation using a local Qwen3-8B judge.
+
+Runs inside SPCS. Evaluates multiple model backends (Cortex REST, HuggingFace vLLM,
+checkpoint vLLM) against the MEDICAL_SOAP_TEST table using section-level LLM-as-judge
+scoring (S, O, A, P evaluated independently).
+
+GPU layout (2x GPU):
+  GPU 0: vLLM for generating completions (hf/checkpoint models)
+  GPU 1: vLLM Qwen3-8B judge server
+
+Environment variables:
+  EVAL_MODELS          — comma-separated model specs, e.g.
+                         "cortex:claude-sonnet-4-6,hf:Qwen/Qwen3-1.7B,checkpoint:/tmp/eval_model"
+  NUM_SAMPLES          — number of test samples to evaluate (default 100)
+  CHECKPOINT_STAGE_PATH— Snowflake stage path for checkpoint model weights
+  SNOWFLAKE_HOST       — SPCS host for REST API calls
+"""
+import ast
+import asyncio
+import atexit
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+
+# ============================================================================
+# SPCS Runtime Fixes (same as run_medical_soap.py)
+# ============================================================================
+
+# Force unbuffered output for SPCS logs
+os.environ["PYTHONUNBUFFERED"] = "1"
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
+# Suppress verbose output
+os.environ["HF_DATASETS_DISABLE_PROGRESS_BARS"] = "1"
+os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
+os.environ["HF_HOME"] = "/tmp/hf_cache"
+os.environ["TRANSFORMERS_CACHE"] = "/tmp/hf_cache"
+os.environ["HUGGINGFACE_HUB_CACHE"] = "/tmp/hf_cache"
+
+# Ensure venv bin is on PATH so subprocesses (vLLM server) use the right Python.
+_venv = os.environ.get("VIRTUAL_ENV", "/opt/venv/snowbook")
+_venv_bin = os.path.join(_venv, "bin")
+_path = os.environ.get("PATH", "")
+if _venv_bin not in _path:
+    os.environ["PATH"] = f"{_venv_bin}:{_path}"
+    print(f"  PATH: prepended {_venv_bin}")
+
+# Fix LD_LIBRARY_PATH for CUDA libs installed via pip (cuDNN, cuBLAS, etc.)
+import site
+import ctypes
+import glob as _glob
+_sp = site.getsitepackages()[0] if site.getsitepackages() else ""
+_nvidia_dirs = []
+if _sp:
+    for _pkg in ["nvidia/cudnn/lib", "nvidia/cublas/lib", "nvidia/cuda_runtime/lib",
+                 "nvidia/cuda_nvrtc/lib", "nvidia/cuda_cupti/lib", "nvidia/cufft/lib",
+                 "nvidia/curand/lib", "nvidia/cusolver/lib", "nvidia/cusparse/lib",
+                 "nvidia/nccl/lib", "nvidia/nvtx/lib", "nvidia/nvjitlink/lib"]:
+        _d = os.path.join(_sp, _pkg)
+        if os.path.isdir(_d):
+            _nvidia_dirs.append(_d)
+if _nvidia_dirs:
+    _existing = os.environ.get("LD_LIBRARY_PATH", "")
+    os.environ["LD_LIBRARY_PATH"] = ":".join(_nvidia_dirs) + (":" + _existing if _existing else "")
+    for _d in _nvidia_dirs:
+        for _so in sorted(_glob.glob(os.path.join(_d, "*.so*"))):
+            try:
+                ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)
+            except OSError:
+                pass
+    print(f"  CUDA libs: preloaded from {len(_nvidia_dirs)} nvidia pip dirs")
+
+# Fix stale torch files from 2.8.0->2.9.1 upgrade in the image.
+import site as _site
+for _sp in _site.getsitepackages() + [_site.getusersitepackages()]:
+    _stale = os.path.join(_sp, "torch", "_inductor", "kernel", "flex_attention.py")
+    if os.path.isfile(_stale):
+        os.remove(_stale)
+        print(f"  Removed stale {_stale}")
+    _stale_c = _stale + "c"
+    if os.path.isfile(_stale_c):
+        os.remove(_stale_c)
+
+# Install AReaL and vLLM with --no-deps from local wheel to avoid torch reinstall.
+print("--- Installing AReaL + vLLM (--no-deps) ---")
+subprocess.check_call([
+    sys.executable, "-m", "pip", "install", "--no-deps", "--quiet",
+    "areal @ git+https://github.com/inclusionAI/AReaL.git@v1.0.1",
+    "/mnt/job_stage/app/vllm-0.14.0-cp38-abi3-manylinux_2_31_x86_64.whl",
+])
+print("  AReaL + vLLM installed")
+
+# ============================================================================
+# Configuration
+# ============================================================================
+import ssl
+import gzip
+import urllib.error
+
+# Detect GPU count and assign layout
+_num_gpus = int(os.environ.get("NVIDIA_VISIBLE_DEVICES", "0,1").count(",")) + 1
+try:
+    result = subprocess.run(
+        ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader"],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode == 0:
+        _num_gpus = len(result.stdout.strip().split("\n"))
+except Exception:
+    pass
+
+JUDGE_GPU = _num_gpus - 1  # Last GPU for judge
+GEN_GPU = 0                # First GPU for generation
+JUDGE_PORT = 38899
+JUDGE_MODEL = os.environ.get("LOCAL_JUDGE_MODEL", "Qwen/Qwen3-8B")
+
+DATA_DATABASE = "RL_TRAINING_DB"
+DATA_SCHEMA = "RL_SCHEMA"
+TEST_TABLE = "MEDICAL_SOAP_TEST"
+
+print("=" * 60)
+print("Medical SOAP Evaluation (SPCS Runtime)")
+print("=" * 60)
+print(f"  GPUs detected:  {_num_gpus}")
+print(f"  Judge GPU:      {JUDGE_GPU} (port {JUDGE_PORT})")
+print(f"  Generation GPU: {GEN_GPU}")
+print(f"  Judge model:    {JUDGE_MODEL}")
+
+
+# ============================================================================
+# SPCS Token / REST API Helpers
+# ============================================================================
+def _get_spcs_token():
+    """Read SPCS OAuth token for REST API calls."""
+    with open("/snowflake/session/token") as f:
+        return f.read().strip()
+
+
+def _query_table(table_name, host):
+    """Query a Snowflake table via REST API and return all rows."""
+    fq_table = f"{DATA_DATABASE}.{DATA_SCHEMA}.{table_name}"
+    url = f"https://{host}/api/v2/statements"
+    payload = {
+        "statement": f"SELECT DIALOGUE, PRED_S, PRED_O, PRED_A, PRED_P FROM {fq_table}",
+        "timeout": 120,
+        "resultSetMetaData": {"format": "jsonv2"},
+        "warehouse": os.environ.get("CORTEX_WAREHOUSE", "ADMIN_WH"),
+        "database": DATA_DATABASE,
+        "schema": DATA_SCHEMA,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    ctx = ssl.create_default_context()
+
+    def _read_response(resp):
+        raw = resp.read()
+        if raw[:2] == b'\x1f\x8b':
+            raw = gzip.decompress(raw)
+        return json.loads(raw.decode("utf-8"))
+
+    token = _get_spcs_token()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    req.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        resp = urllib.request.urlopen(req, context=ctx, timeout=120)
+        result = _read_response(resp)
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8", errors="replace")
+        print(f"  ERROR querying {fq_table}: HTTP {e.code} — {error_body[:500]}")
+        raise
+
+    columns = [col["name"] for col in result["resultSetMetaData"]["rowType"]]
+    statement_handle = result.get("statementHandle", "")
+    all_row_data = result.get("data", [])
+
+    partition_info = result.get("resultSetMetaData", {}).get("partitionInfo", [])
+    if len(partition_info) > 1:
+        print(f"  {fq_table}: {len(partition_info)} partitions, fetching all...")
+        for i in range(1, len(partition_info)):
+            part_url = f"https://{host}/api/v2/statements/{statement_handle}?partition={i}"
+            token = _get_spcs_token()
+            part_req = urllib.request.Request(part_url, method="GET")
+            part_req.add_header("Accept", "application/json")
+            part_req.add_header("Authorization", f"Bearer {token}")
+            try:
+                part_resp = urllib.request.urlopen(part_req, context=ctx, timeout=120)
+                part_result = _read_response(part_resp)
+                all_row_data.extend(part_result.get("data", []))
+            except urllib.error.HTTPError as e:
+                error_body = e.read().decode("utf-8", errors="replace")
+                print(f"  ERROR fetching partition {i}: HTTP {e.code} — {error_body[:200]}")
+                raise
+
+    rows = [dict(zip(columns, row_data)) for row_data in all_row_data]
+    print(f"  Queried {fq_table}: {len(rows)} rows ({len(partition_info)} partition(s))")
+    return rows
+
+
+def _execute_sql(sql_text, host):
+    """Execute arbitrary SQL via REST API and return result."""
+    url = f"https://{host}/api/v2/statements"
+    payload = {
+        "statement": sql_text,
+        "timeout": 120,
+        "resultSetMetaData": {"format": "jsonv2"},
+        "warehouse": os.environ.get("CORTEX_WAREHOUSE", "ADMIN_WH"),
+        "database": DATA_DATABASE,
+        "schema": DATA_SCHEMA,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    ctx = ssl.create_default_context()
+
+    token = _get_spcs_token()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    req.add_header("Authorization", f"Bearer {token}")
+
+    resp = urllib.request.urlopen(req, context=ctx, timeout=120)
+    raw = resp.read()
+    if raw[:2] == b'\x1f\x8b':
+        raw = gzip.decompress(raw)
+    return json.loads(raw.decode("utf-8"))
+
+
+# ============================================================================
+# Checkpoint Download
+# ============================================================================
+def download_checkpoint(stage_path, host):
+    """Download checkpoint from Snowflake stage via presigned URLs."""
+    local_model = "/tmp/eval_model"
+    if os.path.exists(local_model):
+        shutil.rmtree(local_model)
+    os.makedirs(local_model, exist_ok=True)
+
+    list_result = _execute_sql(f"LIST {stage_path}", host)
+    files = [row[0] for row in list_result.get("data", [])]
+    print(f"  Found {len(files)} files on stage")
+
+    stage_parts = stage_path.split("/")
+    stage_name = stage_parts[0]
+    stage_root = stage_name.lstrip("@").split(".")[-1].lower()
+
+    for stage_file in files:
+        if stage_file.lower().startswith(stage_root):
+            rel_path = stage_file[len(stage_root) + 1:]
+        else:
+            rel_path = stage_file
+
+        filename = os.path.basename(rel_path)
+        if not filename:
+            continue
+
+        local_file = os.path.join(local_model, filename)
+        url_result = _execute_sql(
+            f"SELECT GET_PRESIGNED_URL({stage_name}, '{rel_path}')", host,
+        )
+        presigned_url = url_result["data"][0][0]
+        urllib.request.urlretrieve(presigned_url, local_file)
+        size_mb = os.path.getsize(local_file) / 1e6
+        print(f"    {filename}: {size_mb:.1f} MB")
+
+    print(f"  Contents: {os.listdir(local_model)}")
+    return local_model
+
+
+# ============================================================================
+# Judge Server
+# ============================================================================
+_judge_process = None
+
+
+def start_judge_server():
+    """Spawn vLLM OpenAI-compatible server for judging on the last GPU."""
+    global _judge_process
+
+    print(f"\n--- Starting vLLM Judge Server (GPU {JUDGE_GPU}, port {JUDGE_PORT}) ---")
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(JUDGE_GPU)
+
+    cmd = [
+        sys.executable, "-m", "vllm.entrypoints.openai.api_server",
+        "--model", JUDGE_MODEL,
+        "--port", str(JUDGE_PORT),
+        "--dtype", "bfloat16",
+        "--max-model-len", "8192",
+        "--gpu-memory-utilization", "0.90",
+        "--trust-remote-code",
+        "--disable-log-requests",
+        "--enable-prefix-caching",
+    ]
+
+    _judge_process = subprocess.Popen(cmd, env=env, start_new_session=True)
+    atexit.register(_kill_judge)
+
+    # Wait for judge to become healthy (up to 10 minutes)
+    max_wait = 600
+    start_time = time.time()
+    last_log = 0
+
+    while time.time() - start_time < max_wait:
+        if _judge_process.poll() is not None:
+            raise RuntimeError(
+                f"vLLM judge exited with code {_judge_process.returncode}"
+            )
+        try:
+            req = urllib.request.Request(
+                f"http://localhost:{JUDGE_PORT}/health", method="GET",
+            )
+            resp = urllib.request.urlopen(req, timeout=5)
+            if resp.status == 200:
+                print(f"  Judge ready in {time.time() - start_time:.1f}s")
+                return
+        except Exception:
+            pass
+
+        elapsed = time.time() - start_time
+        if elapsed - last_log >= 30:
+            print(f"  Waiting for judge... ({elapsed:.0f}s)")
+            last_log = elapsed
+        time.sleep(5)
+
+    _kill_judge()
+    raise RuntimeError(f"Judge not healthy within {max_wait}s")
+
+
+def _kill_judge():
+    """Kill the judge server process."""
+    global _judge_process
+    if _judge_process and _judge_process.poll() is None:
+        print(f"  Killing judge (PID={_judge_process.pid})...")
+        try:
+            os.killpg(os.getpgid(_judge_process.pid), signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            try:
+                _judge_process.kill()
+            except (ProcessLookupError, OSError):
+                pass
+    _judge_process = None
+
+
+# ============================================================================
+# Generation vLLM Server (for hf/checkpoint models)
+# ============================================================================
+_gen_process = None
+_gen_port = 38900
+_gen_model_name = None
+
+
+def start_gen_server(model_path):
+    """Start a vLLM server on GPU 0 for generating completions."""
+    global _gen_process, _gen_model_name
+
+    # Kill any existing gen server
+    stop_gen_server()
+
+    print(f"\n--- Starting vLLM Generation Server (GPU {GEN_GPU}, port {_gen_port}) ---")
+    print(f"  Model: {model_path}")
+    env = os.environ.copy()
+    env["CUDA_VISIBLE_DEVICES"] = str(GEN_GPU)
+
+    cmd = [
+        sys.executable, "-m", "vllm.entrypoints.openai.api_server",
+        "--model", model_path,
+        "--port", str(_gen_port),
+        "--dtype", "bfloat16",
+        "--max-model-len", "4096",
+        "--gpu-memory-utilization", "0.90",
+        "--trust-remote-code",
+        "--disable-log-requests",
+    ]
+
+    _gen_process = subprocess.Popen(cmd, env=env, start_new_session=True)
+    _gen_model_name = model_path
+
+    # Wait for server to become healthy
+    max_wait = 600
+    start_time = time.time()
+    last_log = 0
+
+    while time.time() - start_time < max_wait:
+        if _gen_process.poll() is not None:
+            raise RuntimeError(
+                f"vLLM gen server exited with code {_gen_process.returncode}"
+            )
+        try:
+            req = urllib.request.Request(
+                f"http://localhost:{_gen_port}/health", method="GET",
+            )
+            resp = urllib.request.urlopen(req, timeout=5)
+            if resp.status == 200:
+                print(f"  Gen server ready in {time.time() - start_time:.1f}s")
+                return
+        except Exception:
+            pass
+
+        elapsed = time.time() - start_time
+        if elapsed - last_log >= 30:
+            print(f"  Waiting for gen server... ({elapsed:.0f}s)")
+            last_log = elapsed
+        time.sleep(5)
+
+    stop_gen_server()
+    raise RuntimeError(f"Gen server not healthy within {max_wait}s")
+
+
+def stop_gen_server():
+    """Stop the generation vLLM server."""
+    global _gen_process, _gen_model_name
+    if _gen_process and _gen_process.poll() is None:
+        print(f"  Killing gen server (PID={_gen_process.pid})...")
+        try:
+            os.killpg(os.getpgid(_gen_process.pid), signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            try:
+                _gen_process.kill()
+            except (ProcessLookupError, OSError):
+                pass
+        _gen_process.wait(timeout=30)
+    _gen_process = None
+    _gen_model_name = None
+
+
+# ============================================================================
+# Model Completion Backends
+# ============================================================================
+def _generate_cortex(model_name, system_prompt, user_prompt, host):
+    """Generate completion via Snowflake Cortex COMPLETE REST API."""
+    # Escape single quotes for SQL
+    sys_escaped = system_prompt.replace("'", "''")
+    user_escaped = user_prompt.replace("'", "''")
+
+    sql = (
+        f"SELECT SNOWFLAKE.CORTEX.COMPLETE("
+        f"'{model_name}', "
+        f"PARSE_JSON('[{{\"role\": \"system\", \"content\": ''{sys_escaped}''}},"
+        f"{{\"role\": \"user\", \"content\": ''{user_escaped}''}}]'), "
+        f"PARSE_JSON('{{\"temperature\": 0, \"max_tokens\": 2048}}')"
+        f") AS response"
+    )
+
+    result = _execute_sql(sql, host)
+    raw = result["data"][0][0]
+    # Cortex COMPLETE returns JSON with "choices" array
+    try:
+        parsed = json.loads(raw)
+        return parsed["choices"][0]["messages"]
+    except (json.JSONDecodeError, KeyError, IndexError):
+        # Some versions return plain text
+        return raw
+
+
+def _generate_vllm(model_name, system_prompt, user_prompt):
+    """Generate completion via local vLLM server on GPU 0."""
+    payload = {
+        "model": model_name,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": 0.0,
+        "max_tokens": 2048,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        f"http://localhost:{_gen_port}/v1/chat/completions",
+        data=body, method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    resp = urllib.request.urlopen(req, timeout=180)
+    result = json.loads(resp.read().decode("utf-8"))
+    return result["choices"][0]["message"]["content"]
+
+
+# ============================================================================
+# Judge Helpers
+# ============================================================================
+def _strip_think_tags(text):
+    """Strip <think>...</think> tags from model response."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<think>.*", "", text, flags=re.DOTALL)
+    return text.strip()
+
+
+def parse_judge_result(raw_response):
+    """Parse judge response and return score (1.0 for pass, 0.0 for fail)."""
+    response = _strip_think_tags(raw_response)
+    result = None
+    response_lower = response.lower()
+
+    # Try to extract JSON from code fence
+    for parse_fn in [json.loads, ast.literal_eval]:
+        try:
+            result = parse_fn(
+                response.split("```json")[-1].split("```")[0].strip()
+            )
+            break
+        except Exception:
+            pass
+
+    # Try to find raw JSON object with verdict key
+    if result is None:
+        json_match = re.search(r'\{[^{}]*"verdict"[^{}]*\}', response, re.IGNORECASE)
+        if json_match:
+            try:
+                result = json.loads(json_match.group())
+            except Exception:
+                pass
+
+    # Fallback: look for verdict string
+    if result is None and '"verdict": "fail"' in response_lower:
+        result = {"verdict": "fail"}
+    if result is None and '"verdict": "pass"' in response_lower:
+        result = {"verdict": "pass"}
+    if result is None and 'verdict": "fail"' in response_lower:
+        result = {"verdict": "fail"}
+    if result is None and 'verdict": "pass"' in response_lower:
+        result = {"verdict": "pass"}
+
+    if result is None:
+        return 0.0
+
+    verdict = result.get("verdict", "").lower()
+    return float(verdict == "pass")
+
+
+async def _call_judge_async(session, system_prompt, user_prompt):
+    """Async call to local vLLM judge server via aiohttp."""
+    payload = {
+        "model": JUDGE_MODEL,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": 0.0,
+        "max_tokens": 512,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+    try:
+        async with session.post(
+            f"http://localhost:{JUDGE_PORT}/v1/chat/completions",
+            json=payload,
+        ) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"Judge HTTP {resp.status}")
+            result = await resp.json()
+        return result["choices"][0]["message"]["content"]
+    except RuntimeError:
+        raise
+    except Exception as e:
+        raise RuntimeError(f"Judge error: {type(e).__name__}: {e}") from None
+
+
+# ============================================================================
+# Evaluation Logic
+# ============================================================================
+async def evaluate_single_sample(session, sample, completion, judge_sys_prompt,
+                                 create_section_judge_prompt):
+    """Judge all 4 SOAP sections of a single sample in parallel.
+
+    Returns dict with keys: format_ok, S, O, A, P, total.
+    """
+    from medical_soap.reward import extract_json_from_response, validate_soap_json
+
+    clean = _strip_think_tags(completion)
+    parsed = extract_json_from_response(clean)
+
+    if parsed is None or not validate_soap_json(parsed):
+        return {"format_ok": False, "S": 0.0, "O": 0.0, "A": 0.0, "P": 0.0, "total": 0.0}
+
+    dialogue = sample["DIALOGUE"]
+    gt = {
+        "S": sample.get("PRED_S", ""),
+        "O": sample.get("PRED_O", ""),
+        "A": sample.get("PRED_A", ""),
+        "P": sample.get("PRED_P", ""),
+    }
+
+    async def _judge_section(key):
+        user_prompt = create_section_judge_prompt(dialogue, key, gt[key], parsed[key])
+        try:
+            raw = await _call_judge_async(session, judge_sys_prompt, user_prompt)
+            return parse_judge_result(raw)
+        except Exception:
+            return 0.0
+
+    scores = await asyncio.gather(
+        _judge_section("S"),
+        _judge_section("O"),
+        _judge_section("A"),
+        _judge_section("P"),
+    )
+
+    return {
+        "format_ok": True,
+        "S": scores[0],
+        "O": scores[1],
+        "A": scores[2],
+        "P": scores[3],
+        "total": 1.0 + sum(scores),  # 1.0 format + section scores
+    }
+
+
+async def evaluate_model(model_spec, samples, host):
+    """Evaluate a single model on all samples.
+
+    Args:
+        model_spec: Model specification string (e.g. "cortex:claude-sonnet-4-6")
+        samples: List of test sample dicts
+        host: Snowflake host for REST API
+
+    Returns:
+        dict with per-section averages and overall scores.
+    """
+    import aiohttp
+
+    # Copy reward module to importable location
+    REWARD_MODULE_DIR = "/tmp/reward_modules"
+    stage_src = "/mnt/job_stage/app"
+    local_dst = os.path.join(REWARD_MODULE_DIR, "medical_soap")
+    if os.path.exists(stage_src) and not os.path.exists(local_dst):
+        os.makedirs(REWARD_MODULE_DIR, exist_ok=True)
+        shutil.copytree(stage_src, local_dst)
+    if REWARD_MODULE_DIR not in sys.path:
+        sys.path.insert(0, REWARD_MODULE_DIR)
+
+    from medical_soap.prompt_utils import (
+        SYSTEM_PROMPT,
+        USER_PROMPT_PREFIX,
+        JUDGE_SECTION_SYSTEM_PROMPT,
+        create_section_judge_prompt,
+    )
+
+    # Parse model spec
+    parts = model_spec.split(":", 1)
+    backend = parts[0]
+    model_name = parts[1] if len(parts) > 1 else parts[0]
+
+    print(f"\n--- Evaluating: {model_spec} ---")
+
+    # Start generation server if needed
+    if backend in ("hf", "checkpoint"):
+        model_path = model_name
+        if backend == "checkpoint":
+            # model_name is the local path (already downloaded)
+            model_path = model_name
+        start_gen_server(model_path)
+
+    # Generate completions
+    completions = []
+    gen_errors = 0
+    for i, sample in enumerate(samples):
+        user_prompt = f"{USER_PROMPT_PREFIX}\n\n{sample['DIALOGUE']}"
+        try:
+            if backend == "cortex":
+                completion = _generate_cortex(model_name, SYSTEM_PROMPT, user_prompt, host)
+            elif backend in ("hf", "checkpoint"):
+                completion = _generate_vllm(_gen_model_name, SYSTEM_PROMPT, user_prompt)
+            else:
+                raise ValueError(f"Unknown backend: {backend}")
+            completions.append(completion)
+        except Exception as e:
+            print(f"  [gen error] Sample {i}: {type(e).__name__}: {e}")
+            completions.append("")
+            gen_errors += 1
+
+        if (i + 1) % 50 == 0:
+            print(f"  Generated {i + 1}/{len(samples)} completions ({gen_errors} errors)")
+
+    print(f"  Generation complete: {len(completions)} completions, {gen_errors} errors")
+
+    # Stop gen server after generating all completions
+    if backend in ("hf", "checkpoint"):
+        stop_gen_server()
+
+    # Judge completions in parallel
+    timeout = aiohttp.ClientTimeout(total=120, sock_connect=5, sock_read=120)
+    async with aiohttp.ClientSession(timeout=timeout) as aio_session:
+        judge_errors = 0
+        results = []
+
+        # Process in batches to avoid overwhelming the judge
+        batch_size = 20
+        for batch_start in range(0, len(samples), batch_size):
+            batch_end = min(batch_start + batch_size, len(samples))
+            batch_tasks = []
+            for j in range(batch_start, batch_end):
+                if completions[j]:
+                    batch_tasks.append(
+                        evaluate_single_sample(
+                            aio_session, samples[j], completions[j],
+                            JUDGE_SECTION_SYSTEM_PROMPT, create_section_judge_prompt,
+                        )
+                    )
+                else:
+                    # Empty completion — score 0
+                    async def _zero():
+                        return {
+                            "format_ok": False, "S": 0.0, "O": 0.0,
+                            "A": 0.0, "P": 0.0, "total": 0.0,
+                        }
+                    batch_tasks.append(_zero())
+
+            batch_results = await asyncio.gather(*batch_tasks, return_exceptions=True)
+            for r in batch_results:
+                if isinstance(r, Exception):
+                    judge_errors += 1
+                    results.append({
+                        "format_ok": False, "S": 0.0, "O": 0.0,
+                        "A": 0.0, "P": 0.0, "total": 0.0,
+                    })
+                else:
+                    results.append(r)
+
+            if (batch_end) % 50 == 0 or batch_end == len(samples):
+                print(f"  Judged {batch_end}/{len(samples)} samples ({judge_errors} errors)")
+
+    # Compute aggregates
+    n = len(results)
+    format_ok_count = sum(1 for r in results if r["format_ok"])
+    avg_S = sum(r["S"] for r in results) / n if n else 0
+    avg_O = sum(r["O"] for r in results) / n if n else 0
+    avg_A = sum(r["A"] for r in results) / n if n else 0
+    avg_P = sum(r["P"] for r in results) / n if n else 0
+    avg_total = sum(r["total"] for r in results) / n if n else 0
+
+    return {
+        "model": model_spec,
+        "n": n,
+        "format_ok": format_ok_count,
+        "format_pct": format_ok_count / n * 100 if n else 0,
+        "S": avg_S,
+        "O": avg_O,
+        "A": avg_A,
+        "P": avg_P,
+        "avg_total": avg_total,
+        "gen_errors": gen_errors,
+        "judge_errors": judge_errors,
+    }
+
+
+# ============================================================================
+# Comparison Table
+# ============================================================================
+def print_comparison_table(results_list):
+    """Print a formatted comparison table of model evaluation results."""
+    print("\n" + "=" * 90)
+    print("EVALUATION RESULTS")
+    print("=" * 90)
+
+    header = (
+        f"{'Model':<40} {'Format%':>7} {'S':>6} {'O':>6} {'A':>6} {'P':>6} "
+        f"{'Avg':>6} {'N':>5}"
+    )
+    print(header)
+    print("-" * 90)
+
+    for r in results_list:
+        model_name = r["model"]
+        if len(model_name) > 38:
+            model_name = model_name[:35] + "..."
+        print(
+            f"{model_name:<40} {r['format_pct']:>6.1f}% "
+            f"{r['S']:>6.3f} {r['O']:>6.3f} {r['A']:>6.3f} {r['P']:>6.3f} "
+            f"{r['avg_total']:>6.2f} {r['n']:>5}"
+        )
+
+    print("-" * 90)
+    print(f"  Score range: 0-5 (1.0 format + 1.0 each for S, O, A, P)")
+    print(f"  Section scores: fraction of samples where judge passed (0.0-1.0)")
+    print("=" * 90)
+
+
+# ============================================================================
+# Main
+# ============================================================================
+def main():
+    host = os.environ.get("SNOWFLAKE_HOST", "")
+    if not host:
+        raise RuntimeError("SNOWFLAKE_HOST not set — required for REST API calls")
+
+    eval_models_str = os.environ.get("EVAL_MODELS", "")
+    if not eval_models_str:
+        raise RuntimeError("EVAL_MODELS not set — provide comma-separated model specs")
+
+    num_samples = int(os.environ.get("NUM_SAMPLES", "100"))
+    checkpoint_stage_path = os.environ.get("CHECKPOINT_STAGE_PATH", "")
+    model_specs = [m.strip() for m in eval_models_str.split(",") if m.strip()]
+
+    print(f"\n  Models to evaluate: {model_specs}")
+    print(f"  Num samples: {num_samples}")
+    if checkpoint_stage_path:
+        print(f"  Checkpoint stage: {checkpoint_stage_path}")
+
+    # 1. Start judge server
+    start_judge_server()
+
+    # 2. Copy reward module to importable location
+    REWARD_MODULE_DIR = "/tmp/reward_modules"
+    stage_src = "/mnt/job_stage/app"
+    local_dst = os.path.join(REWARD_MODULE_DIR, "medical_soap")
+    if os.path.exists(stage_src):
+        os.makedirs(REWARD_MODULE_DIR, exist_ok=True)
+        if os.path.exists(local_dst):
+            shutil.rmtree(local_dst)
+        shutil.copytree(stage_src, local_dst)
+        print(f"  Copied reward module to {local_dst}")
+    if REWARD_MODULE_DIR not in sys.path:
+        sys.path.insert(0, REWARD_MODULE_DIR)
+
+    # 3. Load test data
+    print("\n--- Loading Test Data ---")
+    all_samples = _query_table(TEST_TABLE, host)
+    if num_samples < len(all_samples):
+        all_samples = all_samples[:num_samples]
+    print(f"  Using {len(all_samples)} samples for evaluation")
+
+    # 4. Download checkpoint if any model needs it
+    for spec in model_specs:
+        if spec.startswith("checkpoint:"):
+            if not checkpoint_stage_path:
+                raise RuntimeError(
+                    f"Model {spec} requires CHECKPOINT_STAGE_PATH but it is not set"
+                )
+            print("\n--- Downloading Checkpoint ---")
+            local_path = download_checkpoint(checkpoint_stage_path, host)
+            # Rewrite checkpoint model specs to use local path
+            model_specs = [
+                s.replace(s.split(":", 1)[1], local_path) if s.startswith("checkpoint:") else s
+                for s in model_specs
+            ]
+            break
+
+    # 5. Evaluate each model
+    all_results = []
+    for spec in model_specs:
+        try:
+            result = asyncio.run(evaluate_model(spec, all_samples, host))
+            all_results.append(result)
+        except Exception as e:
+            import traceback
+            print(f"\n  ERROR evaluating {spec}:")
+            print(traceback.format_exc())
+            all_results.append({
+                "model": spec, "n": len(all_samples), "format_ok": 0,
+                "format_pct": 0, "S": 0, "O": 0, "A": 0, "P": 0,
+                "avg_total": 0, "gen_errors": len(all_samples), "judge_errors": 0,
+            })
+
+    # 6. Print comparison table
+    print_comparison_table(all_results)
+
+    # 7. Print detailed per-model stats
+    print("\nDetailed Stats:")
+    for r in all_results:
+        print(f"  {r['model']}:")
+        print(f"    Samples: {r['n']}, Format OK: {r['format_ok']} ({r['format_pct']:.1f}%)")
+        print(f"    Section pass rates: S={r['S']:.3f} O={r['O']:.3f} A={r['A']:.3f} P={r['P']:.3f}")
+        print(f"    Avg total score: {r['avg_total']:.3f}/5.0")
+        print(f"    Gen errors: {r['gen_errors']}, Judge errors: {r['judge_errors']}")
+
+    print("\n" + "=" * 60)
+    print("Evaluation complete.")
+    print("=" * 60)
+
+    # 8. Ensure all output is flushed and captured by SPCS event table
+    sys.stdout.flush()
+    sys.stderr.flush()
+    # Give SPCS log collector time to capture the final output
+    time.sleep(10)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        import traceback
+        print("=" * 60)
+        print("FATAL ERROR:")
+        print(traceback.format_exc())
+        print("=" * 60)
+        sys.stdout.flush()
+        sys.stderr.flush()
+        _kill_judge()
+        stop_gen_server()
+        time.sleep(10)
+        sys.exit(1)
+    finally:
+        # Final cleanup — ensure servers are stopped
+        _kill_judge()
+        stop_gen_server()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        time.sleep(5)

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/prompt_utils.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/prompt_utils.py
@@ -1,0 +1,350 @@
+"""Prompt utilities for Medical SOAP note generation.
+
+This module contains system prompts, user prompts, and helper functions
+for generating and evaluating SOAP notes from doctor-patient dialogues.
+"""
+
+import re
+from typing import Dict
+
+SYSTEM_PROMPT = """\
+You are an expert medical professor specializing in clinical documentation.
+Your task is to generate medically accurate SOAP note summaries from provided
+doctor–patient transcripts.
+
+You must strictly follow these rules:
+
+1. Base the SOAP note ONLY on the information explicitly stated in the transcript.
+   Do not infer or add medical facts not present in the dialogue.
+
+2. Maintain patient confidentiality and use professional, sensitive medical
+   language suitable for clinician-to-clinician communication.
+
+3. Use concise medical terminology and standard abbreviations where appropriate.
+
+4. Structure the output as a single valid JSON object with exactly four top-level
+   keys: "S", "O", "A", and "P".
+
+5. Each key must map to a string value containing the corresponding section text.
+   Do not nest objects or arrays inside these fields.
+
+6. Do NOT include markdown, bullet points, numbering, special characters, or
+   formatting outside of plain text within each field.
+
+7. Do NOT include any explanatory text, headers, or commentary outside the JSON
+   object.
+
+8. Do NOT wrap the output in markdown code fences (e.g., ```json or ```). Output
+   the raw JSON object directly.
+
+SOAP section guidelines:
+
+- "S" (Subjective):
+  Summarize the patient- or caregiver-reported symptoms, concerns, chief complaint,
+  and relevant history. Use the patient's statements as the primary source.
+
+- "O" (Objective):
+  Include measurable or observed findings such as exam findings, imaging results,
+  genetic testing, and other diagnostics. Specify laterality, descriptors, and
+  clinically relevant details. Include normal ranges only if stated.
+
+- "A" (Assessment):
+  Provide a concise clinical assessment synthesizing subjective and objective data.
+  State the primary diagnosis and relevant differential diagnoses when applicable.
+  Mention known or potential complications and overall clinical impression.
+
+- "P" (Plan):
+  Outline the management and follow-up plan, including therapies, referrals,
+  monitoring, and patient or caregiver education. Address adherence or compliance
+  considerations if mentioned.
+
+The final output must be a single valid JSON object and nothing else.
+"""
+
+JUDGE_SYSTEM_PROMPT = """You are a strict medical NLP evaluator assessing SOAP note quality.
+
+You will receive:
+- Original dialogue (source of all medical facts)
+- A SOAP section key (S, O, A, or P)
+- Ground-truth text for that section
+- Model-predicted text for that section
+
+SOAP Section Requirements:
+- S (Subjective): Patient/caregiver-reported symptoms, concerns, chief complaint, history
+- O (Objective): Measurable/observed findings (exam, imaging, labs, diagnostics with specifics)
+- A (Assessment): Clinical assessment synthesizing S+O, diagnosis, differentials, complications
+- P (Plan): Management, therapies, referrals, monitoring, patient education, adherence
+
+Evaluation Criteria (all must pass):
+
+1. FACTUAL ACCURACY (critical):
+   - FAIL if prediction includes facts/details NOT in the dialogue (hallucination)
+   - FAIL if prediction contradicts the dialogue or ground truth
+   
+2. COMPLETENESS (critical):
+   - FAIL if prediction omits key clinically relevant items that are in ground truth
+   - Minor omissions of non-critical details are acceptable
+   
+3. CLINICAL APPROPRIATENESS:
+   - Prediction should use appropriate medical terminology for the section type
+   - Should align with the section's purpose (e.g., S=subjective, not objective findings)
+
+4. ACCEPTABLE VARIATIONS:
+   - Different wording/phrasing is OK if meaning preserved
+   - Synonymous medical terms are OK
+   - Different order of information is OK
+
+Output Requirements:
+Return ONLY valid JSON with exactly these keys:
+- "verdict": must be exactly "pass" or "fail" (lowercase)
+- "reason": concise justification (1-2 sentences max)
+
+Be strict but fair: minor stylistic differences should pass, but any hallucination or missing critical clinical information should fail."""
+
+
+# Separate criterion-specific judge system prompts
+JUDGE_FACTUAL_ACCURACY_SYSTEM_PROMPT = """You are a strict medical NLP evaluator assessing FACTUAL ACCURACY of SOAP notes.
+
+You will receive:
+- Original dialogue (source of all medical facts)
+- Model-predicted SOAP note (JSON with S, O, A, P keys)
+
+Your ONLY task is to evaluate FACTUAL ACCURACY:
+- FAIL if prediction includes ANY facts/details NOT explicitly stated in the dialogue (hallucination)
+- FAIL if prediction contradicts information in the dialogue
+- PASS if all information in the prediction can be traced back to the dialogue
+
+ACCEPTABLE:
+- Different wording/phrasing if meaning is preserved
+- Synonymous medical terms
+- Reasonable clinical inferences that are standard practice
+
+NOT ACCEPTABLE:
+- Adding diagnoses not mentioned or implied in the dialogue
+- Including test results or findings not stated
+- Inventing patient history or symptoms
+
+After your analysis, output a JSON object with exactly these keys:
+- "verdict": must be exactly "pass" or "fail" (lowercase)
+- "reason": concise justification (1-2 sentences max)"""
+
+
+JUDGE_COMPLETENESS_SYSTEM_PROMPT = """You are a strict medical NLP evaluator assessing COMPLETENESS of SOAP notes.
+
+You will receive:
+- Original dialogue (source of all medical facts)
+- Ground-truth SOAP note (reference standard)
+- Model-predicted SOAP note (JSON with S, O, A, P keys)
+
+Your ONLY task is to evaluate COMPLETENESS:
+- FAIL if prediction omits KEY clinically relevant information present in the ground truth
+- Key information includes: chief complaint, significant symptoms, critical findings, primary diagnosis, essential treatment plans
+- Minor omissions of non-critical details are acceptable
+
+ACCEPTABLE OMISSIONS:
+- Stylistic details
+- Redundant information
+- Minor supporting details
+
+NOT ACCEPTABLE OMISSIONS:
+- Chief complaint or primary symptoms
+- Key diagnostic findings
+- Primary diagnosis
+- Critical treatment decisions
+
+After your analysis, output a JSON object with exactly these keys:
+- "verdict": must be exactly "pass" or "fail" (lowercase)
+- "reason": concise justification (1-2 sentences max)"""
+
+
+JUDGE_CLINICAL_APPROPRIATENESS_SYSTEM_PROMPT = """You are a strict medical NLP evaluator assessing CLINICAL APPROPRIATENESS of SOAP notes.
+
+You will receive:
+- Model-predicted SOAP note (JSON with S, O, A, P keys)
+
+Your ONLY task is to evaluate CLINICAL APPROPRIATENESS:
+- Check if appropriate medical terminology is used
+- Verify each section contains the right type of information:
+  * S (Subjective): Patient-reported symptoms, concerns, history - NOT objective findings
+  * O (Objective): Measurable/observed findings, test results - NOT patient complaints
+  * A (Assessment): Clinical synthesis, diagnosis - NOT raw data
+  * P (Plan): Treatment, follow-up, referrals - NOT assessment
+- FAIL if sections contain misplaced information types
+- FAIL if unprofessional or inappropriate language is used
+
+ACCEPTABLE:
+- Various levels of detail
+- Different organizational styles
+- Both formal and semi-formal medical language
+
+NOT ACCEPTABLE:
+- Objective findings in Subjective section
+- Subjective complaints in Objective section
+- Treatment plans in Assessment section
+- Diagnoses only in Plan section
+
+After your analysis, output a JSON object with exactly these keys:
+- "verdict": must be exactly "pass" or "fail" (lowercase)
+- "reason": concise justification (1-2 sentences max)"""
+
+
+# Section-based judge system prompt for RL training (judges S, O, A, P separately)
+# This is a streamlined version of JUDGE_SYSTEM_PROMPT optimized for RL reward computation
+JUDGE_SECTION_SYSTEM_PROMPT = """You are a strict medical NLP evaluator assessing a single SOAP section.
+
+You will receive:
+- Original dialogue (source of all medical facts)
+- A SOAP section key (S, O, A, or P)
+- Ground-truth text for that section
+- Model-predicted text for that section
+
+CRITICAL PRE-CHECK (evaluate FIRST, before anything else):
+- FAIL IMMEDIATELY if prediction is empty, blank, whitespace-only, or missing
+- FAIL IMMEDIATELY if prediction is less than 10 characters
+- An empty or near-empty prediction can NEVER pass, regardless of other criteria
+
+SOAP Section Requirements:
+- S (Subjective): Patient/caregiver-reported symptoms, concerns, chief complaint, history
+- O (Objective): Measurable/observed findings (exam, imaging, labs, diagnostics with specifics)
+- A (Assessment): Clinical assessment synthesizing S+O, diagnosis, differentials, complications
+- P (Plan): Management, therapies, referrals, monitoring, patient education, adherence
+
+Evaluation Criteria (all must pass):
+
+1. FACTUAL ACCURACY (critical):
+   - FAIL if prediction includes facts/details NOT in the dialogue (hallucination)
+   - FAIL if prediction contradicts the dialogue or ground truth
+   
+2. COMPLETENESS (critical):
+   - FAIL if prediction omits key clinically relevant items that are in ground truth
+   - Minor omissions of non-critical details are acceptable
+   
+3. CLINICAL APPROPRIATENESS:
+   - Prediction should use appropriate medical terminology for the section type
+   - Should align with the section's purpose (e.g., S=subjective, not objective findings)
+
+4. ACCEPTABLE VARIATIONS:
+   - Different wording/phrasing is OK if meaning preserved
+   - Synonymous medical terms are OK
+   - Different order of information is OK
+
+Output ONLY valid JSON with exactly these keys:
+- "verdict": must be exactly "pass" or "fail" (lowercase)
+- "reason": concise justification (1-2 sentences max)
+
+Be strict but fair: minor stylistic differences should pass, but any hallucination or missing critical clinical information should fail."""
+
+USER_PROMPT_PREFIX = "Create a Medical SOAP note summary from the following dialogue:"
+
+SOAP_RESPONSE_RE = re.compile(r"S:\s*(.*?)O:\s*(.*?)A:\s*(.*?)P:\s*(.*)", re.S)
+
+
+def create_user_prompt(dialogue: str) -> str:
+    """Create user prompt from dialogue."""
+    return f"{USER_PROMPT_PREFIX}\n\n{dialogue}"
+
+
+def extract_SOAP_response(response: str) -> Dict[str, str]:
+    """Extract SOAP sections from a text response using regex pattern."""
+    m = SOAP_RESPONSE_RE.match(response)
+    if not m:
+        raise ValueError("Could not parse SOAP record")
+    return {
+        "S": m.group(1).strip(),
+        "O": m.group(2).strip(),
+        "A": m.group(3).strip(),
+        "P": m.group(4).strip(),
+    }
+
+
+def create_judge_prompt(
+    dialogue: str, key: str, ground_truth: str, prediction: str
+) -> str:
+    """Create a prompt for LLM-as-judge evaluation of a SOAP section."""
+    return f"""Evaluate SOAP key: {key}
+
+DIALOGUE:
+{dialogue}
+
+GROUND TRUTH ({key}):
+{ground_truth}
+
+PREDICTION ({key}):
+{prediction}
+
+Return JSON only."""
+
+
+def create_factual_accuracy_prompt(dialogue: str, prediction_json: str) -> str:
+    """Create a prompt for evaluating factual accuracy of a SOAP note."""
+    return f"""Evaluate the FACTUAL ACCURACY of the following SOAP note.
+
+ORIGINAL DIALOGUE:
+{dialogue}
+
+MODEL PREDICTION:
+{prediction_json}
+
+Check if ALL information in the prediction can be traced back to the dialogue.
+Return JSON only."""
+
+
+def create_completeness_prompt(
+    dialogue: str, ground_truth_json: str, prediction_json: str
+) -> str:
+    """Create a prompt for evaluating completeness of a SOAP note."""
+    return f"""Evaluate the COMPLETENESS of the following SOAP note.
+
+ORIGINAL DIALOGUE:
+{dialogue}
+
+GROUND TRUTH:
+{ground_truth_json}
+
+MODEL PREDICTION:
+{prediction_json}
+
+Check if key clinically relevant information from the ground truth is present.
+Return JSON only."""
+
+
+def create_clinical_appropriateness_prompt(prediction_json: str) -> str:
+    """Create a prompt for evaluating clinical appropriateness of a SOAP note."""
+    return f"""Evaluate the CLINICAL APPROPRIATENESS of the following SOAP note.
+
+MODEL PREDICTION:
+{prediction_json}
+
+Check if each section (S, O, A, P) contains the appropriate type of information.
+Return JSON only."""
+
+
+def create_section_judge_prompt(
+    dialogue: str, key: str, ground_truth: str, prediction: str
+) -> str:
+    """Create a prompt for LLM-as-judge evaluation of a single SOAP section.
+    
+    This version appends /no_think to disable Qwen3's thinking mode for faster
+    inference during RL training.
+    
+    Args:
+        dialogue: The original doctor-patient dialogue.
+        key: The SOAP section key (S, O, A, or P).
+        ground_truth: The ground truth text for this section.
+        prediction: The model's predicted text for this section.
+    
+    Returns:
+        The formatted judge prompt with /no_think suffix.
+    """
+    return f"""Evaluate SOAP section: {key}
+
+DIALOGUE:
+{dialogue}
+
+GROUND TRUTH ({key}):
+{ground_truth}
+
+PREDICTION ({key}):
+{prediction}
+
+Return JSON only. /no_think"""

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/requirements.txt
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/requirements.txt
@@ -1,0 +1,58 @@
+# Runtime pip dependencies for SPCS runtime image (snowbooks:2.4.1-thong-pytorch-29)
+# Image provides: PyTorch 2.9.1, Ray 2.53.0, flash-attn, datasets, accelerate, peft, CUDA 12.8
+# AReaL + vLLM are installed with --no-deps in run_policy_rl.py (vLLM from bundled wheel)
+
+# === Training ===
+wandb
+deepspeed
+math-verify==0.8.0
+aiofiles
+hydra-core
+omegaconf
+colorlog
+portalocker
+tensorboardX
+torchdata
+swanlab
+
+# === AReaL compat ===
+transformers==4.57.1
+
+# === vLLM 0.14.0 Python deps (wheel installed --no-deps) ===
+openai>=1.99.1
+anthropic==0.71.0
+blake3
+orjson
+partial-json-parser
+lm-format-enforcer==0.11.3
+outlines_core==0.2.11
+compressed-tensors==0.13.0
+depyf==0.20.0
+prometheus-fastapi-instrumentator>=7.0.0
+tiktoken>=0.6.0
+mistral-common[image]>=1.8.8
+msgspec
+xgrammar==0.1.29
+flashinfer-python==0.5.3
+gguf>=0.17.0
+loguru
+uvloop
+diskcache==5.6.3
+lark==1.2.2
+llguidance>=1.3.0,<1.4.0
+pyzmq>=25.0.0
+cloudpickle
+watchfiles
+python-json-logger
+ninja
+pybase64
+cbor2
+ijson
+setproctitle
+openai-harmony>=0.0.3
+opencv-python-headless>=4.11.0
+model-hosting-container-standards>=0.1.10,<1.0.0
+grpcio-reflection>=1.76.0
+fastapi[standard]>=0.115.0
+mcp
+numba==0.61.2

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/reward.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/reward.py
@@ -1,0 +1,195 @@
+"""Reward functions for Medical SOAP RL training.
+
+This module implements reward functions for evaluating SOAP note generation,
+including JSON parsing validation and optional LLM-as-judge evaluation.
+"""
+
+import json
+import logging
+import re
+
+logger = logging.getLogger("MedicalSOAPReward")
+
+# Required keys for valid SOAP JSON output
+SOAP_KEYS = {"S", "O", "A", "P"}
+
+
+def extract_json_from_response(response: str) -> dict | None:
+    """Extract JSON object from model response.
+
+    Handles common cases like markdown code fences and extra whitespace.
+
+    Args:
+        response: Raw model response string.
+
+    Returns:
+        Parsed JSON dict if successful, None otherwise.
+    """
+    # Try direct parsing first
+    try:
+        return json.loads(response.strip())
+    except json.JSONDecodeError:
+        pass
+
+    # Try to extract JSON from markdown code fences
+    # Pattern matches ```json ... ``` or ``` ... ```
+    json_pattern = r"```(?:json)?\s*(\{[\s\S]*?\})\s*```"
+    match = re.search(json_pattern, response)
+    if match:
+        try:
+            return json.loads(match.group(1))
+        except json.JSONDecodeError:
+            pass
+
+    # Try to find any JSON object in the response
+    # Look for the first { and last }
+    first_brace = response.find("{")
+    last_brace = response.rfind("}")
+    if first_brace != -1 and last_brace > first_brace:
+        try:
+            return json.loads(response[first_brace : last_brace + 1])
+        except json.JSONDecodeError:
+            pass
+
+    return None
+
+
+def validate_soap_json(parsed: dict) -> bool:
+    """Validate that parsed JSON has exactly the required SOAP keys.
+
+    Args:
+        parsed: Parsed JSON dictionary.
+
+    Returns:
+        True if valid SOAP structure, False otherwise.
+    """
+    if not isinstance(parsed, dict):
+        return False
+
+    # Check for exact keys
+    if set(parsed.keys()) != SOAP_KEYS:
+        return False
+
+    # Check that all values are strings (non-empty preferred but not required)
+    for key in SOAP_KEYS:
+        if not isinstance(parsed[key], str):
+            return False
+
+    return True
+
+
+def medical_soap_reward_fn(
+    prompt: str,
+    completions: str,
+    prompt_ids: list[int],
+    completion_ids: list[int],
+    pred_S: str,
+    pred_O: str,
+    pred_A: str,
+    pred_P: str,
+    **kwargs,
+) -> float:
+    """Compute reward for SOAP note generation.
+
+    This reward function uses a two-stage approach:
+    1. JSON parsing check: Verifies the output is valid JSON with S, O, A, P keys
+    2. Content quality bonus: Provides additional reward for non-empty sections
+
+    Args:
+        prompt: The input prompt string.
+        completions: The model's completion/response string.
+        prompt_ids: Token IDs of the prompt.
+        completion_ids: Token IDs of the completion.
+        pred_S: Ground truth Subjective section.
+        pred_O: Ground truth Objective section.
+        pred_A: Ground truth Assessment section.
+        pred_P: Ground truth Plan section.
+        **kwargs: Additional keyword arguments (ignored).
+
+    Returns:
+        Reward value between 0.0 and 1.0:
+        - 0.0: Invalid JSON or missing/wrong keys
+        - 0.5: Valid JSON structure with correct keys
+        - 0.75: Valid JSON with all non-empty sections
+        - 1.0: Valid JSON with substantial content in all sections
+    """
+    try:
+        # Stage 1: JSON parsing check
+        parsed = extract_json_from_response(completions)
+
+        if parsed is None:
+            logger.debug("Failed to parse JSON from response")
+            return 0.0
+
+        if not validate_soap_json(parsed):
+            logger.debug(f"Invalid SOAP structure. Keys found: {parsed.keys()}")
+            return 0.0
+
+        # Stage 2: Content quality bonus
+        reward = 0.5  # Base reward for valid structure
+
+        # Check for non-empty sections
+        non_empty_count = sum(
+            1 for key in SOAP_KEYS if parsed[key] and len(parsed[key].strip()) > 0
+        )
+
+        if non_empty_count == 4:
+            reward = 0.75  # All sections have some content
+
+            # Additional bonus for substantial content (at least 20 chars each)
+            substantial_count = sum(
+                1 for key in SOAP_KEYS if len(parsed[key].strip()) >= 20
+            )
+            if substantial_count == 4:
+                reward = 1.0  # All sections have substantial content
+
+        return reward
+
+    except Exception as e:
+        logger.warning(f"Exception in medical_soap_reward_fn: {e}", exc_info=True)
+        return 0.0
+
+
+def medical_soap_reward_fn_strict(
+    prompt: str,
+    completions: str,
+    prompt_ids: list[int],
+    completion_ids: list[int],
+    pred_S: str,
+    pred_O: str,
+    pred_A: str,
+    pred_P: str,
+    **kwargs,
+) -> float:
+    """Strict binary reward function for SOAP note generation.
+
+    Returns 1.0 only if the output is valid JSON with all SOAP keys and
+    non-empty content in each section. Otherwise returns 0.0.
+
+    This is useful for later stages of training when the model has learned
+    the basic format and needs stricter feedback.
+
+    Args:
+        Same as medical_soap_reward_fn.
+
+    Returns:
+        1.0 if valid and complete, 0.0 otherwise.
+    """
+    try:
+        parsed = extract_json_from_response(completions)
+
+        if parsed is None:
+            return 0.0
+
+        if not validate_soap_json(parsed):
+            return 0.0
+
+        # Require all sections to have substantial content
+        for key in SOAP_KEYS:
+            if len(parsed[key].strip()) < 10:
+                return 0.0
+
+        return 1.0
+
+    except Exception:
+        return 0.0

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
@@ -92,12 +92,12 @@ for _sp in _site.getsitepackages() + [_site.getusersitepackages()]:
     if os.path.isfile(_stale_c):
         os.remove(_stale_c)
 
-# Install AReaL and vLLM with --no-deps from local wheel to avoid torch reinstall.
+# Install AReaL and vLLM with --no-deps to avoid torch reinstall.
 print("--- Installing AReaL + vLLM (--no-deps) ---")
 subprocess.check_call([
     sys.executable, "-m", "pip", "install", "--no-deps", "--quiet",
     "areal @ git+https://github.com/inclusionAI/AReaL.git@v1.0.1",
-    "/mnt/job_stage/app/vllm-0.14.0-cp38-abi3-manylinux_2_31_x86_64.whl",
+    "vllm==0.14.0",
 ])
 print("  AReaL + vLLM installed")
 

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
@@ -80,18 +80,6 @@ if _nvidia_dirs:
                 pass
     print(f"  CUDA libs: preloaded from {len(_nvidia_dirs)} nvidia pip dirs")
 
-# Fix stale torch files from 2.8.0->2.9.1 upgrade in the image.
-# The old flex_attention.py wasn't removed, causing "duplicate template name" error.
-import site as _site
-for _sp in _site.getsitepackages() + [_site.getusersitepackages()]:
-    _stale = os.path.join(_sp, "torch", "_inductor", "kernel", "flex_attention.py")
-    if os.path.isfile(_stale):
-        os.remove(_stale)
-        print(f"  Removed stale {_stale}")
-    _stale_c = _stale + "c"
-    if os.path.isfile(_stale_c):
-        os.remove(_stale_c)
-
 # Install AReaL and vLLM with --no-deps to avoid torch reinstall.
 print("--- Installing AReaL + vLLM (--no-deps) ---")
 subprocess.check_call([

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
@@ -416,8 +416,7 @@ def _call_local_judge_sync(system_prompt, user_prompt, _max_retries=3):
             {"role": "user", "content": user_prompt},
         ],
         "temperature": 0.0,
-        "max_tokens": 512,
-        "chat_template_kwargs": {"enable_thinking": False},
+        "max_tokens": 2048,
     }
     body = json.dumps(payload).encode("utf-8")
 
@@ -450,7 +449,7 @@ async def _call_local_judge_async(system_prompt, user_prompt):
     import aiohttp
 
     if _aiohttp_session is None or _aiohttp_session.closed:
-        timeout = aiohttp.ClientTimeout(total=60, sock_connect=5, sock_read=60)
+        timeout = aiohttp.ClientTimeout(total=180, sock_connect=5, sock_read=180)
         _aiohttp_session = aiohttp.ClientSession(timeout=timeout)
 
     payload = {
@@ -460,8 +459,7 @@ async def _call_local_judge_async(system_prompt, user_prompt):
             {"role": "user", "content": user_prompt},
         ],
         "temperature": 0.0,
-        "max_tokens": 512,
-        "chat_template_kwargs": {"enable_thinking": False},
+        "max_tokens": 2048,
     }
     body = json.dumps(payload)
 
@@ -536,10 +534,17 @@ def medical_soap_combined_reward_fn(
     format_reward = 1.0
 
     # Stage 2: Section-level judge evaluation
-    dialogue = ""
-    ground_truth_sections = {"S": "", "O": "", "A": "", "P": ""}
+    # AReaL passes dataset fields as **kwargs (not as data=dict)
+    dialogue = kwargs.get("dialogue", "")
+    ground_truth_sections = {
+        "S": kwargs.get("pred_S", ""),
+        "O": kwargs.get("pred_O", ""),
+        "A": kwargs.get("pred_A", ""),
+        "P": kwargs.get("pred_P", ""),
+    }
 
-    if data and isinstance(data, dict):
+    # Fallback: check data dict if kwargs are empty (for direct calls)
+    if not dialogue and data and isinstance(data, dict):
         dialogue = data.get("dialogue", "")
         ground_truth_sections = {
             "S": data.get("pred_S", ""),
@@ -618,10 +623,17 @@ async def async_medical_soap_reward_fn(
     format_reward = 1.0
 
     # Stage 2: Section-level judge evaluation (all 4 in parallel)
-    dialogue = ""
-    ground_truth_sections = {"S": "", "O": "", "A": "", "P": ""}
+    # AReaL passes dataset fields as **kwargs (not as data=dict)
+    dialogue = kwargs.get("dialogue", "")
+    ground_truth_sections = {
+        "S": kwargs.get("pred_S", ""),
+        "O": kwargs.get("pred_O", ""),
+        "A": kwargs.get("pred_A", ""),
+        "P": kwargs.get("pred_P", ""),
+    }
 
-    if data and isinstance(data, dict):
+    # Fallback: check data dict if kwargs are empty (for direct calls)
+    if not dialogue and data and isinstance(data, dict):
         dialogue = data.get("dialogue", "")
         ground_truth_sections = {
             "S": data.get("pred_S", ""),
@@ -665,10 +677,16 @@ async def async_medical_soap_reward_fn(
         "sections_total": section_total,
     }
 
-    if _CALL_COUNT <= 3:
+    if _CALL_COUNT <= 5:
         print(f"[async_medical_soap_reward] Call #{_CALL_COUNT}: "
-              f"format={format_reward:.1f} S={score_S:.1f} O={score_O:.1f} "
-              f"A={score_A:.1f} P={score_P:.1f} total={combined:.1f}")
+              f"dialogue_len={len(dialogue)} "
+              f"gt_S_len={len(ground_truth_sections['S'])} "
+              f"gt_O_len={len(ground_truth_sections['O'])} "
+              f"gt_A_len={len(ground_truth_sections['A'])} "
+              f"gt_P_len={len(ground_truth_sections['P'])} "
+              f"format={format_reward:.0f} S={score_S:.0f} O={score_O:.0f} "
+              f"A={score_A:.0f} P={score_P:.0f} total={combined:.1f}")
+        sys.stdout.flush()
 
     if _CALL_COUNT % _LOG_INTERVAL == 0:
         total = _JUDGE_SUCCESS + _JUDGE_FAIL

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
@@ -1,0 +1,957 @@
+#!/usr/bin/env python3
+"""
+Medical SOAP RL Training with Local vLLM Judge on SPCS Runtime Image.
+
+Trains a model to generate SOAP notes from doctor-patient dialogues using
+section-level LLM-as-judge reward (S, O, A, P evaluated independently).
+
+This version uses the SPCS managed runtime image (no custom Docker build).
+Ray is pre-started by the runtime; packages installed via pip_requirements.
+
+GPU layout (8x A100-40GB):
+  GPUs 0-3: AReaL training
+  GPUs 4-7: vLLM judge servers (one per GPU)
+
+Reward structure (max 5.0):
+  - Format reward: 1.0 if valid JSON with S, O, A, P keys, else 0.0
+  - Section rewards: 1.0 each for S, O, A, P (max 4.0) via LLM judge
+"""
+import ast
+import atexit
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+
+# Force unbuffered output for SPCS logs
+os.environ["PYTHONUNBUFFERED"] = "1"
+sys.stdout.reconfigure(line_buffering=True)
+sys.stderr.reconfigure(line_buffering=True)
+
+# Suppress verbose output
+os.environ["HF_DATASETS_DISABLE_PROGRESS_BARS"] = "1"
+os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
+os.environ["HF_HOME"] = "/tmp/hf_cache"
+os.environ["TRANSFORMERS_CACHE"] = "/tmp/hf_cache"
+os.environ["HUGGINGFACE_HUB_CACHE"] = "/tmp/hf_cache"
+
+# Ensure venv bin is on PATH so subprocesses (vLLM server) use the right Python.
+# The vLLM rollout server is launched via subprocess and needs access to pip-installed
+# packages in the venv. Also ensure VIRTUAL_ENV is set for subprocess activation.
+_venv = os.environ.get("VIRTUAL_ENV", "/opt/venv/snowbook")
+_venv_bin = os.path.join(_venv, "bin")
+_path = os.environ.get("PATH", "")
+if _venv_bin not in _path:
+    os.environ["PATH"] = f"{_venv_bin}:{_path}"
+    print(f"  PATH: prepended {_venv_bin}")
+
+# Fix LD_LIBRARY_PATH for CUDA libs installed via pip (cuDNN, cuBLAS, etc.)
+# The SPCS runtime installs nvidia-cudnn-cu12 etc. as pip packages which place
+# .so files in site-packages, but torch looks for them on LD_LIBRARY_PATH.
+# We set LD_LIBRARY_PATH AND preload libcudnn via ctypes (since LD_LIBRARY_PATH
+# changes after process start only affect dlopen with full path, not by name).
+import site
+import ctypes
+import glob as _glob
+_sp = site.getsitepackages()[0] if site.getsitepackages() else ""
+_nvidia_dirs = []
+if _sp:
+    for _pkg in ["nvidia/cudnn/lib", "nvidia/cublas/lib", "nvidia/cuda_runtime/lib",
+                 "nvidia/cuda_nvrtc/lib", "nvidia/cuda_cupti/lib", "nvidia/cufft/lib",
+                 "nvidia/curand/lib", "nvidia/cusolver/lib", "nvidia/cusparse/lib",
+                 "nvidia/nccl/lib", "nvidia/nvtx/lib", "nvidia/nvjitlink/lib"]:
+        _d = os.path.join(_sp, _pkg)
+        if os.path.isdir(_d):
+            _nvidia_dirs.append(_d)
+if _nvidia_dirs:
+    _existing = os.environ.get("LD_LIBRARY_PATH", "")
+    os.environ["LD_LIBRARY_PATH"] = ":".join(_nvidia_dirs) + (":" + _existing if _existing else "")
+    # Preload critical .so files so dlopen can find them by name
+    for _d in _nvidia_dirs:
+        for _so in sorted(_glob.glob(os.path.join(_d, "*.so*"))):
+            try:
+                ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)
+            except OSError:
+                pass
+    print(f"  CUDA libs: preloaded from {len(_nvidia_dirs)} nvidia pip dirs")
+
+# Fix stale torch files from 2.8.0->2.9.1 upgrade in the image.
+# The old flex_attention.py wasn't removed, causing "duplicate template name" error.
+import site as _site
+for _sp in _site.getsitepackages() + [_site.getusersitepackages()]:
+    _stale = os.path.join(_sp, "torch", "_inductor", "kernel", "flex_attention.py")
+    if os.path.isfile(_stale):
+        os.remove(_stale)
+        print(f"  Removed stale {_stale}")
+    _stale_c = _stale + "c"
+    if os.path.isfile(_stale_c):
+        os.remove(_stale_c)
+
+# Install AReaL and vLLM with --no-deps from local wheel to avoid torch reinstall.
+print("--- Installing AReaL + vLLM (--no-deps) ---")
+subprocess.check_call([
+    sys.executable, "-m", "pip", "install", "--no-deps", "--quiet",
+    "areal @ git+https://github.com/inclusionAI/AReaL.git@v1.0.1",
+    "/mnt/job_stage/app/vllm-0.14.0-cp38-abi3-manylinux_2_31_x86_64.whl",
+])
+print("  AReaL + vLLM installed")
+
+# GPU layout: GPUs 0-3 for AReaL, GPUs 4-7 for judges
+JUDGE_GPUS = [6, 7]
+NUM_AREAL_GPUS = 6
+
+JUDGE_BASE_PORT = int(os.environ.get("LOCAL_JUDGE_BASE_PORT", "38899"))
+JUDGE_PORTS = [JUDGE_BASE_PORT + i for i in range(len(JUDGE_GPUS))]
+os.environ["NUM_GPUS"] = str(NUM_AREAL_GPUS)
+
+JUDGE_MODEL = os.environ.get("LOCAL_JUDGE_MODEL", "Qwen/Qwen3-8B")
+
+print("=" * 60)
+print("Medical SOAP RL Training (SPCS Runtime)")
+print("=" * 60)
+print(f"  Judge model:  {JUDGE_MODEL}")
+print(f"  Judge GPUs:   {JUDGE_GPUS} ({len(JUDGE_GPUS)} judges)")
+print(f"  Judge ports:  {JUDGE_PORTS}")
+print(f"  AReaL GPUs:   0-{NUM_AREAL_GPUS - 1} ({NUM_AREAL_GPUS} total)")
+
+
+# ============================================================================
+# Local vLLM Judge Server
+# ============================================================================
+_judge_processes = []
+
+
+def start_judge_servers():
+    """Spawn vLLM OpenAI-compatible servers on dedicated GPUs."""
+    global _judge_processes
+
+    print(f"\n--- Starting {len(JUDGE_GPUS)} vLLM Judge Servers ---")
+
+    for gpu, port in zip(JUDGE_GPUS, JUDGE_PORTS):
+        print(f"  Launching judge on GPU {gpu}, port {port}...")
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = str(gpu)
+
+        cmd = [
+            sys.executable, "-m", "vllm.entrypoints.openai.api_server",
+            "--model", JUDGE_MODEL,
+            "--port", str(port),
+            "--dtype", "bfloat16",
+            "--max-model-len", "8192",
+            "--gpu-memory-utilization", "0.90",
+            "--trust-remote-code",
+            "--disable-log-requests",
+            "--enable-prefix-caching",
+        ]
+
+        proc = subprocess.Popen(cmd, env=env)
+        _judge_processes.append((gpu, port, proc))
+
+    atexit.register(_kill_judges)
+
+    # Wait for all judges to become healthy (up to 10 minutes)
+    max_wait = 600
+    start_time = time.time()
+    last_log = 0
+    healthy = set()
+
+    while time.time() - start_time < max_wait and len(healthy) < len(JUDGE_GPUS):
+        for i, (gpu, port, proc) in enumerate(_judge_processes):
+            if i in healthy:
+                continue
+            if proc.poll() is not None:
+                raise RuntimeError(
+                    f"vLLM judge on GPU {gpu} port {port} exited with code {proc.returncode}"
+                )
+            try:
+                req = urllib.request.Request(f"http://localhost:{port}/health", method="GET")
+                resp = urllib.request.urlopen(req, timeout=5)
+                if resp.status == 200:
+                    healthy.add(i)
+                    print(f"  Judge GPU {gpu} port {port} ready ({len(healthy)}/{len(JUDGE_GPUS)})")
+            except Exception:
+                pass
+
+        elapsed = time.time() - start_time
+        if elapsed - last_log >= 30:
+            print(f"  Waiting for judges... {len(healthy)}/{len(JUDGE_GPUS)} ready ({elapsed:.0f}s)")
+            last_log = elapsed
+        if len(healthy) < len(JUDGE_GPUS):
+            time.sleep(5)
+
+    if len(healthy) < len(JUDGE_GPUS):
+        _kill_judges()
+        raise RuntimeError(f"Only {len(healthy)}/{len(JUDGE_GPUS)} judges healthy within {max_wait}s")
+
+    print(f"  All {len(JUDGE_GPUS)} judges ready in {time.time() - start_time:.1f}s")
+
+
+def _kill_judges():
+    """Kill all judge server processes."""
+    global _judge_processes
+    for gpu, port, proc in _judge_processes:
+        if proc.poll() is None:
+            print(f"  Killing judge on GPU {gpu} port {port} (PID={proc.pid})...")
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+            except (ProcessLookupError, OSError):
+                try:
+                    proc.kill()
+                except (ProcessLookupError, OSError):
+                    pass
+    _judge_processes = []
+
+
+# ============================================================================
+# Data Preparation
+# ============================================================================
+TRAIN_TABLE = "MEDICAL_SOAP_TRAIN"
+EVAL_TABLE = "MEDICAL_SOAP_TEST"
+DATA_DATABASE = "RL_TRAINING_DB"
+DATA_SCHEMA = "RL_SCHEMA"
+
+
+def _get_spcs_token():
+    """Read SPCS OAuth token for REST API calls."""
+    with open("/snowflake/session/token") as f:
+        return f.read().strip()
+
+
+def _query_table(table_name, host):
+    """Query a Snowflake table via REST API and return all rows."""
+    import ssl
+    import gzip
+    import urllib.error
+
+    fq_table = f"{DATA_DATABASE}.{DATA_SCHEMA}.{table_name}"
+    url = f"https://{host}/api/v2/statements"
+    payload = {
+        "statement": f"SELECT DIALOGUE, PRED_S, PRED_O, PRED_A, PRED_P FROM {fq_table}",
+        "timeout": 120,
+        "resultSetMetaData": {"format": "jsonv2"},
+        "warehouse": os.environ.get("CORTEX_WAREHOUSE", "ADMIN_WH"),
+        "database": DATA_DATABASE,
+        "schema": DATA_SCHEMA,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    ctx = ssl.create_default_context()
+
+    def _read_response(resp):
+        raw = resp.read()
+        if raw[:2] == b'\x1f\x8b':
+            raw = gzip.decompress(raw)
+        return json.loads(raw.decode("utf-8"))
+
+    token = _get_spcs_token()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    req.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        resp = urllib.request.urlopen(req, context=ctx, timeout=120)
+        result = _read_response(resp)
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode("utf-8", errors="replace")
+        print(f"  ERROR querying {fq_table}: HTTP {e.code} — {error_body[:500]}")
+        raise
+
+    columns = [col["name"] for col in result["resultSetMetaData"]["rowType"]]
+    statement_handle = result.get("statementHandle", "")
+    all_row_data = result.get("data", [])
+
+    partition_info = result.get("resultSetMetaData", {}).get("partitionInfo", [])
+    if len(partition_info) > 1:
+        print(f"  {fq_table}: {len(partition_info)} partitions, fetching all...")
+        for i in range(1, len(partition_info)):
+            part_url = f"https://{host}/api/v2/statements/{statement_handle}?partition={i}"
+            token = _get_spcs_token()
+            part_req = urllib.request.Request(part_url, method="GET")
+            part_req.add_header("Accept", "application/json")
+            part_req.add_header("Authorization", f"Bearer {token}")
+            try:
+                part_resp = urllib.request.urlopen(part_req, context=ctx, timeout=120)
+                part_result = _read_response(part_resp)
+                all_row_data.extend(part_result.get("data", []))
+            except urllib.error.HTTPError as e:
+                error_body = e.read().decode("utf-8", errors="replace")
+                print(f"  ERROR fetching partition {i}: HTTP {e.code} — {error_body[:200]}")
+                raise
+
+    rows = [dict(zip(columns, row_data)) for row_data in all_row_data]
+    print(f"  Queried {fq_table}: {len(rows)} rows ({len(partition_info)} partition(s))")
+    return rows
+
+
+# ============================================================================
+# Dataset Loading
+# ============================================================================
+def load_medical_soap_dataset(dataset_config, tokenizer):
+    """Load medical SOAP dataset from a Snowflake table.
+
+    Returns HF Dataset with columns:
+      question, answer, messages, dialogue, pred_S, pred_O, pred_A, pred_P
+    """
+    from datasets import Dataset
+    from medical_soap.prompt_utils import SYSTEM_PROMPT, USER_PROMPT_PREFIX
+
+    table_name = dataset_config.path
+    host = os.environ.get("SNOWFLAKE_HOST", "")
+    if not host:
+        raise RuntimeError("SNOWFLAKE_HOST not set — required for table queries")
+
+    rows = _query_table(table_name, host)
+
+    records = []
+    for row in rows:
+        dialogue = row["DIALOGUE"]
+        pred_s = row.get("PRED_S", "")
+        pred_o = row.get("PRED_O", "")
+        pred_a = row.get("PRED_A", "")
+        pred_p = row.get("PRED_P", "")
+
+        user_prompt = f"{USER_PROMPT_PREFIX}\n\n{dialogue}"
+
+        records.append({
+            "question": user_prompt,
+            "answer": json.dumps({"S": pred_s, "O": pred_o, "A": pred_a, "P": pred_p}),
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            "dialogue": dialogue,
+            "pred_S": pred_s,
+            "pred_O": pred_o,
+            "pred_A": pred_a,
+            "pred_P": pred_p,
+        })
+
+    dataset = Dataset.from_list(records)
+    print(f"  Loaded {len(records)} records from {table_name}")
+    return dataset
+
+
+# ============================================================================
+# Judge Helpers
+# ============================================================================
+_JUDGE_URLS = [f"http://localhost:{p}/v1/chat/completions" for p in JUDGE_PORTS]
+_aiohttp_session = None
+_call_counter = None
+
+
+def _strip_think_tags(text):
+    """Strip <think>...</think> tags from model response."""
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL)
+    text = re.sub(r"<think>.*", "", text, flags=re.DOTALL)
+    return text.strip()
+
+
+def parse_judge_result(raw_response):
+    """Parse judge response and return score (1.0 for pass, 0.0 for fail).
+
+    Handles Qwen3's <think>...</think> reasoning tags by stripping them first.
+    """
+    response = _strip_think_tags(raw_response)
+
+    result = None
+    response_lower = response.lower()
+
+    # Try to extract JSON from code fence
+    for parse_fn in [json.loads, ast.literal_eval]:
+        try:
+            result = parse_fn(
+                response.split("```json")[-1].split("```")[0].strip()
+            )
+            break
+        except Exception:
+            pass
+
+    # Try to find raw JSON object with verdict key
+    if result is None:
+        json_match = re.search(r'\{[^{}]*"verdict"[^{}]*\}', response, re.IGNORECASE)
+        if json_match:
+            try:
+                result = json.loads(json_match.group())
+            except Exception:
+                pass
+
+    # Fallback: look for verdict string
+    if result is None and '"verdict": "fail"' in response_lower:
+        result = {"verdict": "fail"}
+    if result is None and '"verdict": "pass"' in response_lower:
+        result = {"verdict": "pass"}
+    if result is None and 'verdict": "fail"' in response_lower:
+        result = {"verdict": "fail"}
+    if result is None and 'verdict": "pass"' in response_lower:
+        result = {"verdict": "pass"}
+
+    if result is None:
+        return 0.0
+
+    verdict = result.get("verdict", "").lower()
+    return float(verdict == "pass")
+
+
+def _call_local_judge_sync(system_prompt, user_prompt, _max_retries=3):
+    """Synchronous call to a local vLLM judge server.
+
+    Returns raw response content string.
+    """
+    global _call_counter
+    if _call_counter is None:
+        _call_counter = os.getpid() % len(_JUDGE_URLS)
+
+    judge_url = _JUDGE_URLS[_call_counter % len(_JUDGE_URLS)]
+    _call_counter += 1
+
+    payload = {
+        "model": JUDGE_MODEL,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": 0.0,
+        "max_tokens": 512,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    body = json.dumps(payload).encode("utf-8")
+
+    last_err = None
+    for attempt in range(_max_retries):
+        try:
+            req = urllib.request.Request(
+                judge_url, data=body, method="POST",
+                headers={"Content-Type": "application/json"},
+            )
+            resp = urllib.request.urlopen(req, timeout=180)
+            result = json.loads(resp.read().decode("utf-8"))
+            return result["choices"][0]["message"]["content"]
+        except Exception as e:
+            last_err = e
+            if attempt < _max_retries - 1:
+                time.sleep(1)
+                continue
+            raise RuntimeError(
+                f"Local judge failed after {_max_retries} attempts: {e}"
+            ) from None
+
+
+async def _call_local_judge_async(system_prompt, user_prompt):
+    """Async call to a local vLLM judge server via aiohttp.
+
+    Returns raw response content string. No retries — fail fast.
+    """
+    global _aiohttp_session
+    import aiohttp
+
+    if _aiohttp_session is None or _aiohttp_session.closed:
+        timeout = aiohttp.ClientTimeout(total=60, sock_connect=5, sock_read=60)
+        _aiohttp_session = aiohttp.ClientSession(timeout=timeout)
+
+    payload = {
+        "model": JUDGE_MODEL,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": 0.0,
+        "max_tokens": 512,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    body = json.dumps(payload)
+
+    # Route by user_prompt hash for prefix cache reuse
+    judge_idx = hash(user_prompt) % len(_JUDGE_URLS)
+    judge_url = _JUDGE_URLS[judge_idx]
+
+    try:
+        async with _aiohttp_session.post(
+            judge_url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+        ) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"Local judge HTTP {resp.status} from {judge_url}")
+            result = await resp.json()
+        return result["choices"][0]["message"]["content"]
+    except RuntimeError:
+        raise
+    except Exception as e:
+        raise RuntimeError(f"Local judge error: {type(e).__name__}: {e}") from None
+
+
+# ============================================================================
+# Reward Functions
+# ============================================================================
+_CALL_COUNT = 0
+_JUDGE_SUCCESS = 0
+_JUDGE_FAIL = 0
+_LOG_INTERVAL = 20
+
+
+def medical_soap_combined_reward_fn(
+    prompt, response, prompt_ids=None, completion_ids=None,
+    ground_truth=None, data=None, **kwargs,
+):
+    """Synchronous reward function for medical SOAP RL training.
+
+    Compatible with AReaL's RLVRWorkflow reward_fn signature.
+
+    Reward structure (0-5):
+      - Format reward: 1.0 if valid JSON with S, O, A, P keys, else 0.0
+      - Section rewards: 1.0 each for S, O, A, P via LLM judge (0-4)
+
+    Args:
+        prompt: The input prompt string.
+        response: The model's completion/response string.
+        data: Full dataset record dict with dialogue, pred_S/O/A/P.
+
+    Returns:
+        float: Reward value in [0.0, 5.0].
+    """
+    global _CALL_COUNT, _JUDGE_SUCCESS, _JUDGE_FAIL
+    _CALL_COUNT += 1
+
+    from medical_soap.reward import extract_json_from_response, validate_soap_json
+    from medical_soap.prompt_utils import (
+        JUDGE_SECTION_SYSTEM_PROMPT,
+        create_section_judge_prompt,
+    )
+
+    # Strip <think> tags from model response
+    clean_response = _strip_think_tags(response)
+
+    # Stage 1: JSON format check
+    parsed = extract_json_from_response(clean_response)
+    if parsed is None or not validate_soap_json(parsed):
+        if _CALL_COUNT <= 3:
+            print(f"[medical_soap_reward] Call #{_CALL_COUNT}: format invalid, reward=0.0")
+        return 0.0
+
+    format_reward = 1.0
+
+    # Stage 2: Section-level judge evaluation
+    dialogue = ""
+    ground_truth_sections = {"S": "", "O": "", "A": "", "P": ""}
+
+    if data and isinstance(data, dict):
+        dialogue = data.get("dialogue", "")
+        ground_truth_sections = {
+            "S": data.get("pred_S", ""),
+            "O": data.get("pred_O", ""),
+            "A": data.get("pred_A", ""),
+            "P": data.get("pred_P", ""),
+        }
+
+    section_total = 0.0
+    for key in ["S", "O", "A", "P"]:
+        user_prompt = create_section_judge_prompt(
+            dialogue, key, ground_truth_sections[key], parsed[key],
+        )
+        try:
+            raw_response = _call_local_judge_sync(JUDGE_SECTION_SYSTEM_PROMPT, user_prompt)
+            score = parse_judge_result(raw_response)
+            _JUDGE_SUCCESS += 1
+        except Exception:
+            _JUDGE_FAIL += 1
+            score = 0.0
+        section_total += score
+
+    combined = format_reward + section_total
+
+    if _CALL_COUNT <= 3:
+        print(f"[medical_soap_reward] Call #{_CALL_COUNT}: "
+              f"format={format_reward:.1f} sections={section_total:.1f} total={combined:.1f}")
+
+    if _CALL_COUNT % _LOG_INTERVAL == 0:
+        total = _JUDGE_SUCCESS + _JUDGE_FAIL
+        pct = (_JUDGE_FAIL / total * 100) if total else 0
+        print(f"[medical_soap_reward] Stats @ call {_CALL_COUNT}: "
+              f"judge {_JUDGE_SUCCESS}/{total} ok ({pct:.1f}% fail)")
+
+    return combined
+
+
+async def async_medical_soap_reward_fn(
+    prompt, response, prompt_ids=None, completion_ids=None,
+    ground_truth=None, data=None, **kwargs,
+):
+    """Async reward function for medical SOAP RL training.
+
+    Native asyncio version that uses aiohttp to call local vLLM judges.
+    Returns (reward, sub_scores_dict) for W&B logging.
+
+    Args:
+        prompt: The input prompt string.
+        response: The model's completion/response string.
+        data: Full dataset record dict with dialogue, pred_S/O/A/P.
+
+    Returns:
+        tuple: (float reward in [0.0, 5.0], dict of sub-scores)
+    """
+    import asyncio
+
+    global _CALL_COUNT, _JUDGE_SUCCESS, _JUDGE_FAIL
+    _CALL_COUNT += 1
+
+    from medical_soap.reward import extract_json_from_response, validate_soap_json
+    from medical_soap.prompt_utils import (
+        JUDGE_SECTION_SYSTEM_PROMPT,
+        create_section_judge_prompt,
+    )
+
+    # Strip <think> tags from model response
+    clean_response = _strip_think_tags(response)
+
+    # Stage 1: JSON format check
+    parsed = extract_json_from_response(clean_response)
+    if parsed is None or not validate_soap_json(parsed):
+        if _CALL_COUNT <= 3:
+            print(f"[async_medical_soap_reward] Call #{_CALL_COUNT}: format invalid, reward=0.0")
+        return 0.0, {"format_reward": 0.0, "S": 0.0, "O": 0.0, "A": 0.0, "P": 0.0}
+
+    format_reward = 1.0
+
+    # Stage 2: Section-level judge evaluation (all 4 in parallel)
+    dialogue = ""
+    ground_truth_sections = {"S": "", "O": "", "A": "", "P": ""}
+
+    if data and isinstance(data, dict):
+        dialogue = data.get("dialogue", "")
+        ground_truth_sections = {
+            "S": data.get("pred_S", ""),
+            "O": data.get("pred_O", ""),
+            "A": data.get("pred_A", ""),
+            "P": data.get("pred_P", ""),
+        }
+
+    async def _judge_section(key):
+        user_prompt = create_section_judge_prompt(
+            dialogue, key, ground_truth_sections[key], parsed[key],
+        )
+        try:
+            raw_response = await _call_local_judge_async(
+                JUDGE_SECTION_SYSTEM_PROMPT, user_prompt,
+            )
+            score = parse_judge_result(raw_response)
+            return score
+        except Exception:
+            return 0.0
+
+    results = await asyncio.gather(
+        _judge_section("S"),
+        _judge_section("O"),
+        _judge_section("A"),
+        _judge_section("P"),
+    )
+    score_S, score_O, score_A, score_P = results
+
+    # Track judge stats (approximate — parallel calls counted together)
+    _JUDGE_SUCCESS += 4
+    section_total = score_S + score_O + score_A + score_P
+    combined = format_reward + section_total
+
+    sub_scores = {
+        "format_reward": format_reward,
+        "S": score_S,
+        "O": score_O,
+        "A": score_A,
+        "P": score_P,
+        "sections_total": section_total,
+    }
+
+    if _CALL_COUNT <= 3:
+        print(f"[async_medical_soap_reward] Call #{_CALL_COUNT}: "
+              f"format={format_reward:.1f} S={score_S:.1f} O={score_O:.1f} "
+              f"A={score_A:.1f} P={score_P:.1f} total={combined:.1f}")
+
+    if _CALL_COUNT % _LOG_INTERVAL == 0:
+        total = _JUDGE_SUCCESS + _JUDGE_FAIL
+        pct = (_JUDGE_FAIL / total * 100) if total else 0
+        print(f"[async_medical_soap_reward] Stats @ call {_CALL_COUNT}: "
+              f"judge {_JUDGE_SUCCESS}/{total} ok ({pct:.1f}% fail)")
+
+    return combined, sub_scores
+
+
+# ============================================================================
+# AReaL Reward API Patch
+# ============================================================================
+_NEW_CALL_METHOD = '''\
+    _async_reward_fn_resolved = None
+
+    async def __call__(self, *args, **kwargs) -> float:
+        """Native async reward — bypasses ProcessPoolExecutor.
+        Patched by run_medical_soap.py.
+        """
+        cls = type(self)
+        if cls._async_reward_fn_resolved is None:
+            try:
+                from medical_soap.run_medical_soap import async_medical_soap_reward_fn
+                cls._async_reward_fn_resolved = async_medical_soap_reward_fn
+                logger.info("AsyncRewardWrapper: using native async reward path")
+            except ImportError:
+                logger.warning("async_medical_soap_reward_fn not found, falling back to sync path")
+                cls._async_reward_fn_resolved = False
+
+        if cls._async_reward_fn_resolved and cls._async_reward_fn_resolved is not False:
+            result = await asyncio.wait_for(
+                cls._async_reward_fn_resolved(*args, **kwargs),
+                timeout=self.timeout_seconds,
+            )
+            if isinstance(result, tuple):
+                reward, sub_scores = result
+                from areal.utils import stats_tracker
+                from areal.infra import workflow_context
+                scope = workflow_context.stat_scope()
+                stats_tracker.get(scope).scalar(**{
+                    f"reward/{k}": v for k, v in sub_scores.items()
+                })
+                return reward
+            return result
+
+        # Fallback: original ProcessPoolExecutor path
+        with self._lock:
+            executor = self._executors.get(self._executor_key)
+        if executor is None:
+            raise RuntimeError("ProcessPoolExecutor has been shut down")
+        loop = asyncio.get_event_loop()
+        future = loop.run_in_executor(
+            executor, partial(self.reward_fn, *args, **kwargs),
+        )
+        return await asyncio.wait_for(future, timeout=self.timeout_seconds)'''
+
+
+def _patch_reward_api():
+    """Patch AReaL's AsyncRewardWrapper for native async + longer timeout."""
+    for path in ["/opt/venv/snowbook/lib/python3.12/site-packages/areal/api/reward_api.py",
+                 "/opt/venv/snowbook/lib/python3.11/site-packages/areal/api/reward_api.py",
+                 "/AReaL/src/areal/api/reward_api.py",
+                 "/AReaL/areal/api/reward_api.py"]:
+        if not os.path.exists(path):
+            continue
+
+        with open(path, "r") as f:
+            content = f.read()
+        original = content
+
+        # Patch 1: timeout 15s -> 300s
+        content = re.sub(
+            r'timeout_seconds:\s*float\s*=\s*15\b',
+            'timeout_seconds: float = 300',
+            content,
+        )
+
+        # Patch 2: replace __call__ with native async version
+        pattern = r'(    async def __call__\(self.*?\n)(.*?)(?=\n    (?:def |async def |@)|$)'
+        match = re.search(pattern, content, re.DOTALL)
+        if match:
+            content = content[:match.start()] + _NEW_CALL_METHOD + content[match.end():]
+
+        if content != original:
+            with open(path, "w") as f:
+                f.write(content)
+            print(f"  Patched {path}: timeout=300s, native async __call__")
+        else:
+            print(f"  WARNING: No patches matched in {path}")
+        return
+
+    print("  WARNING: reward_api.py not found")
+
+
+# ============================================================================
+# Checkpoint Download (warm-start)
+# ============================================================================
+def download_checkpoint(stage_path):
+    """Download checkpoint from Snowflake stage via presigned URLs."""
+    import ssl
+    import urllib.error
+
+    local_model = "/tmp/init_model"
+    if os.path.exists(local_model):
+        shutil.rmtree(local_model)
+    os.makedirs(local_model, exist_ok=True)
+
+    host = os.environ.get("SNOWFLAKE_HOST", "")
+    ctx = ssl.create_default_context()
+    api_url = f"https://{host}/api/v2/statements"
+
+    def _run_sql(sql_text):
+        token = _get_spcs_token()
+        payload = json.dumps({
+            "statement": sql_text,
+            "timeout": 120,
+            "resultSetMetaData": {"format": "jsonv2"},
+            "warehouse": os.environ.get("CORTEX_WAREHOUSE", "ADMIN_WH"),
+            "database": DATA_DATABASE,
+            "schema": DATA_SCHEMA,
+        }).encode("utf-8")
+        req = urllib.request.Request(api_url, data=payload, method="POST")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Accept", "application/json")
+        req.add_header("Authorization", f"Bearer {token}")
+        try:
+            resp = urllib.request.urlopen(req, context=ctx, timeout=120)
+            return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            body = e.read().decode("utf-8", errors="replace")
+            print(f"  SQL REST API error: HTTP {e.code} — {body[:500]}")
+            raise
+
+    # List and download files
+    list_result = _run_sql(f"LIST {stage_path}")
+    files = [row[0] for row in list_result.get("data", [])]
+    print(f"  Found {len(files)} files on stage")
+
+    stage_parts = stage_path.split("/")
+    stage_name = stage_parts[0]
+    stage_root = stage_name.lstrip("@").split(".")[-1].lower()
+
+    for stage_file in files:
+        if stage_file.lower().startswith(stage_root):
+            rel_path = stage_file[len(stage_root) + 1:]
+        else:
+            rel_path = stage_file
+
+        filename = os.path.basename(rel_path)
+        if not filename:
+            continue
+
+        local_file = os.path.join(local_model, filename)
+        url_result = _run_sql(f"SELECT GET_PRESIGNED_URL({stage_name}, '{rel_path}')")
+        presigned_url = url_result["data"][0][0]
+        urllib.request.urlretrieve(presigned_url, local_file)
+        size_mb = os.path.getsize(local_file) / 1e6
+        print(f"    {filename}: {size_mb:.1f} MB")
+
+    print(f"  Contents: {os.listdir(local_model)}")
+    return local_model
+
+
+# ============================================================================
+# Main
+# ============================================================================
+def main():
+    import ray
+
+    # 1. Start local vLLM judges
+    start_judge_servers()
+
+    # 2. Patch AReaL reward API
+    print("\n--- Patching reward_api.py ---")
+    _patch_reward_api()
+
+    # 3. Copy reward module to local filesystem
+    REWARD_MODULE_DIR = "/tmp/reward_modules"
+    stage_src = "/mnt/job_stage/app"
+    local_dst = os.path.join(REWARD_MODULE_DIR, "medical_soap")
+    if os.path.exists(stage_src):
+        os.makedirs(REWARD_MODULE_DIR, exist_ok=True)
+        if os.path.exists(local_dst):
+            shutil.rmtree(local_dst)
+        shutil.copytree(stage_src, local_dst)
+        print(f"  Copied reward module to {local_dst}")
+
+    sys.path.insert(0, REWARD_MODULE_DIR)
+    existing_pypath = os.environ.get("PYTHONPATH", "")
+    os.environ["PYTHONPATH"] = (
+        f"{REWARD_MODULE_DIR}:{existing_pypath}" if existing_pypath
+        else REWARD_MODULE_DIR
+    )
+    print(f"  PYTHONPATH={os.environ['PYTHONPATH']}")
+
+    # 4. Connect to Ray (pre-started by SPCS runtime)
+    print("\n--- Ray Init ---")
+    judge_ports_str = ",".join(str(p) for p in JUDGE_PORTS)
+    env_vars = {
+        "PYTHONPATH": os.environ.get("PYTHONPATH", ""),
+        "PATH": os.environ.get("PATH", ""),
+        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
+        "VIRTUAL_ENV": os.environ.get("VIRTUAL_ENV", ""),
+        "HF_HOME": "/tmp/hf_cache",
+        "TRANSFORMERS_CACHE": "/tmp/hf_cache",
+        "LOCAL_JUDGE_PORTS": judge_ports_str,
+        "LOCAL_JUDGE_MODEL": JUDGE_MODEL,
+    }
+
+    ray.init(address="auto", ignore_reinit_error=True,
+             runtime_env={"env_vars": env_vars})
+    print(f"  Connected to Ray: {ray.cluster_resources().get('GPU', 0)} GPUs")
+
+    # 5. Import AReaL
+    from areal import PPOTrainer
+    from areal.api.cli_args import GRPOConfig, load_expr_config
+    from areal.utils.hf_utils import load_hf_tokenizer
+
+    # 6. Load config
+    config, _ = load_expr_config(sys.argv[1:], GRPOConfig)
+
+    # 6b. Warm-start from checkpoint (if configured)
+    init_stage_path = os.environ.get("INIT_MODEL_STAGE_PATH", "")
+    if init_stage_path:
+        print(f"\n--- Loading Init Checkpoint ---")
+        print(f"  Stage path: {init_stage_path}")
+        local_model = download_checkpoint(init_stage_path)
+        config.actor.path = local_model
+        config.ref.path = local_model
+        config.vllm.model = local_model
+        config.tokenizer_path = local_model
+        print(f"  actor.path -> {local_model}")
+
+    tokenizer = load_hf_tokenizer(config.tokenizer_path)
+
+    # 7. Load datasets
+    print("\n--- Dataset Loading ---")
+    train_dataset = load_medical_soap_dataset(config.train_dataset, tokenizer)
+    valid_dataset = load_medical_soap_dataset(config.valid_dataset, tokenizer)
+
+    # 8. Configure workflow
+    reward_fn_path = "medical_soap.run_medical_soap.medical_soap_combined_reward_fn"
+    workflow_kwargs = dict(
+        reward_fn=reward_fn_path,
+        gconfig=config.gconfig,
+        tokenizer=config.tokenizer_path,
+        enable_thinking=False,
+    )
+    eval_workflow_kwargs = workflow_kwargs.copy()
+    eval_workflow_kwargs["gconfig"] = config.gconfig.new(temperature=0.6)
+
+    # 9. Train
+    print("\n--- Training ---")
+    print(f"  Reward function: {reward_fn_path}")
+    print(f"  Judges: {len(JUDGE_GPUS)}x local vLLM @ ports {JUDGE_PORTS}")
+    print(f"  Checkpoints saved directly to: {config.saver.fileroot}")
+
+    with PPOTrainer(
+        config,
+        train_dataset=train_dataset,
+        valid_dataset=valid_dataset,
+    ) as trainer:
+        trainer.train(
+            workflow="areal.workflow.rlvr.RLVRWorkflow",
+            workflow_kwargs=workflow_kwargs,
+            eval_workflow="areal.workflow.rlvr.RLVRWorkflow",
+            eval_workflow_kwargs=eval_workflow_kwargs,
+        )
+
+    print("\n" + "=" * 60)
+    print("Training complete. Model exported to stage.")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        import traceback
+        print("=" * 60)
+        print("FATAL ERROR:")
+        print(traceback.format_exc())
+        print("=" * 60)
+        _kill_judges()
+        sys.exit(1)

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
@@ -50,18 +50,63 @@ if _venv_bin not in _path:
     os.environ["PATH"] = f"{_venv_bin}:{_path}"
     print(f"  PATH: prepended {_venv_bin}")
 
-# Install AReaL and vLLM with --no-deps to avoid torch reinstall.
-print("--- Installing AReaL + vLLM (--no-deps) ---")
+# Fix LD_LIBRARY_PATH for CUDA libs installed via pip (cuDNN, cuBLAS, etc.)
+# The SPCS runtime installs nvidia-cudnn-cu12 etc. as pip packages which place
+# .so files in site-packages, but torch looks for them on LD_LIBRARY_PATH.
+# We set LD_LIBRARY_PATH AND preload libcudnn via ctypes (since LD_LIBRARY_PATH
+# changes after process start only affect dlopen with full path, not by name).
+import site
+import ctypes
+import glob as _glob
+_sp = site.getsitepackages()[0] if site.getsitepackages() else ""
+_nvidia_dirs = []
+if _sp:
+    for _pkg in ["nvidia/cudnn/lib", "nvidia/cublas/lib", "nvidia/cuda_runtime/lib",
+                 "nvidia/cuda_nvrtc/lib", "nvidia/cuda_cupti/lib", "nvidia/cufft/lib",
+                 "nvidia/curand/lib", "nvidia/cusolver/lib", "nvidia/cusparse/lib",
+                 "nvidia/nccl/lib", "nvidia/nvtx/lib", "nvidia/nvjitlink/lib"]:
+        _d = os.path.join(_sp, _pkg)
+        if os.path.isdir(_d):
+            _nvidia_dirs.append(_d)
+if _nvidia_dirs:
+    _existing = os.environ.get("LD_LIBRARY_PATH", "")
+    os.environ["LD_LIBRARY_PATH"] = ":".join(_nvidia_dirs) + (":" + _existing if _existing else "")
+    # Preload critical .so files so dlopen can find them by name
+    for _d in _nvidia_dirs:
+        for _so in sorted(_glob.glob(os.path.join(_d, "*.so*"))):
+            try:
+                ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)
+            except OSError:
+                pass
+    print(f"  CUDA libs: preloaded from {len(_nvidia_dirs)} nvidia pip dirs")
+
+# Fix stale torch files from 2.8.0->2.9.1 upgrade in the image.
+# The old flex_attention.py wasn't removed, causing "duplicate template name" error.
+import site as _site
+for _sp in _site.getsitepackages() + [_site.getusersitepackages()]:
+    _stale = os.path.join(_sp, "torch", "_inductor", "kernel", "flex_attention.py")
+    if os.path.isfile(_stale):
+        os.remove(_stale)
+        print(f"  Removed stale {_stale}")
+    _stale_c = _stale + "c"
+    if os.path.isfile(_stale_c):
+        os.remove(_stale_c)
+
+# Install AReaL, vLLM, and SGLang with --no-deps to avoid torch reinstall.
+print("--- Installing AReaL + vLLM + SGLang (--no-deps) ---")
 subprocess.check_call([
     sys.executable, "-m", "pip", "install", "--no-deps", "--quiet",
     "areal @ git+https://github.com/inclusionAI/AReaL.git@v1.0.1",
-    "vllm==0.14.0",
+    "/mnt/job_stage/app/vllm-0.14.0-cp38-abi3-manylinux_2_31_x86_64.whl",
+    "sglang==0.5.7",
+    "sgl-kernel==0.3.20",
+    "torchao==0.9.0",
 ])
-print("  AReaL + vLLM installed")
+print("  AReaL + vLLM + SGLang installed")
 
 # GPU layout: GPUs 0-3 for AReaL, GPUs 4-7 for judges
-JUDGE_GPUS = [6, 7]
-NUM_AREAL_GPUS = 6
+JUDGE_GPUS = [5, 6, 7]
+NUM_AREAL_GPUS = 5
 
 JUDGE_BASE_PORT = int(os.environ.get("LOCAL_JUDGE_BASE_PORT", "38899"))
 JUDGE_PORTS = [JUDGE_BASE_PORT + i for i in range(len(JUDGE_GPUS))]
@@ -107,7 +152,7 @@ def start_judge_servers():
             "--enable-prefix-caching",
         ]
 
-        proc = subprocess.Popen(cmd, env=env)
+        proc = subprocess.Popen(cmd, env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         _judge_processes.append((gpu, port, proc))
 
     atexit.register(_kill_judges)
@@ -703,6 +748,449 @@ _NEW_CALL_METHOD = '''\
         return await asyncio.wait_for(future, timeout=self.timeout_seconds)'''
 
 
+def _patch_sglang_lora():
+    """Patch AReaL for SGLang + LoRA compatibility.
+
+    Fixes from local testing (CHANGES.md):
+    3. Version 0 LoRA guard in sglang_remote.py — skip LoRA path at version 0
+    4. Skip tokenizer save for LoRA in fsdp_engine.py — prevents added_tokens.json
+       from confusing SGLang's LoRAConfig
+    """
+    import glob as _g
+
+    areal_dirs = _g.glob("/opt/venv/snowbook/lib/python3.*/site-packages/areal/")
+    if not areal_dirs:
+        print("  WARNING: areal package not found for SGLang patches")
+        return
+    areal_dir = areal_dirs[0]
+
+    patched = []
+
+    # Fix 3: Version 0 LoRA guard in sglang_remote.py
+    sglang_remote = os.path.join(areal_dir, "engine", "sglang_remote.py")
+    if os.path.exists(sglang_remote):
+        with open(sglang_remote, "r") as f:
+            content = f.read()
+        if "# PATCHED: version 0 guard" not in content:
+            old = 'payload["lora_path"] = get_versioned_lora_name(lora_name, version)'
+            new = (
+                '# PATCHED: version 0 guard — no LoRA loaded yet at version 0\n'
+                '            if version > 0:\n'
+                '                _lp = get_versioned_lora_name(lora_name, version)\n'
+                '                payload["lora_path"] = _lp\n'
+                '                print(f"[DIAG] build_generation_request: lora_path={_lp}, version={version}", flush=True)'
+            )
+            if old in content:
+                content = content.replace(old, new, 1)
+                with open(sglang_remote, "w") as f:
+                    f.write(content)
+                patched.append("sglang_remote.py: version 0 LoRA guard")
+            else:
+                print(f"  WARNING: Fix 3 patch target not found in {sglang_remote}")
+                print(f"           Expected: payload[\"lora_path\"] = get_versioned_lora_name(...)")
+                print(f"           Patch NOT applied.")
+
+    # Fix 4: Reorder _update_weights_from_disk + skip tokenizer for LoRA.
+    # v1.0.1 has two bugs:
+    #   Bug 1 (race): calls rollout_engine.update_weights_from_disk BEFORE saving
+    #     weights to disk → SGLang tries to load a path that doesn't exist → 400
+    #   Bug 2 (tokenizer): _save_model_to_hf saves tokenizer alongside LoRA weights,
+    #     including added_tokens.json → SGLang LoRAConfig sets lora_added_tokens_size=26
+    #     → fails memory pool check → 400
+    # Fix: save first (skip tokenizer for LoRA), then tell SGLang to load.
+    fsdp_engine = os.path.join(areal_dir, "engine", "fsdp_engine.py")
+    if os.path.exists(fsdp_engine):
+        with open(fsdp_engine, "r") as f:
+            content = f.read()
+        if "# PATCHED: save first, skip tokenizer for LoRA" not in content:
+            old = (
+                "    def _update_weights_from_disk(self, meta: WeightUpdateMeta):\n"
+                "        fut = Future()\n"
+                "\n"
+                "        if dist.get_rank() == 0:\n"
+                "            fut = self.rollout_engine.update_weights_from_disk(meta)\n"
+                "\n"
+                "        assert meta.path is not None\n"
+                "        self._save_model_to_hf(meta.path, self.tokenizer, self.processor)\n"
+                "        # dist.barrier() are called when _save_model_to_hf finished"
+            )
+            new = (
+                "    def _update_weights_from_disk(self, meta: WeightUpdateMeta):\n"
+                "        # PATCHED: save first, skip tokenizer for LoRA, bypass FSDP2 collective\n"
+                "        import time as _t\n"
+                "        _rank = dist.get_rank()\n"
+                "        def _log(msg):\n"
+                "            _m = f'[DIAG {_t.strftime(\"%H:%M:%S\")}] [rank {_rank}] {msg}'\n"
+                "            print(_m, flush=True)\n"
+                "        _log(f'_update_weights_from_disk ENTER use_lora={meta.use_lora} path={meta.path}')\n"
+                "        assert meta.path is not None\n"
+                "\n"
+                "        if meta.use_lora:\n"
+                "            # LoRA: save adapter via get_model_state_dict + safetensors\n"
+                "            # model.save_pretrained crashes due to safetensors _find_shared_tensors\n"
+                "            # accessing FSDP2-offloaded storage. Use state_dict directly.\n"
+                "            _log('LoRA save: get_model_state_dict + safetensors (dp=1)')\n"
+                "            from torch.distributed.checkpoint.state_dict import StateDictOptions, get_model_state_dict\n"
+                "            _opts = StateDictOptions(full_state_dict=True, cpu_offload=True)\n"
+                "            _sd = get_model_state_dict(self.model, options=_opts)\n"
+                "            _lora_sd = {k: v for k, v in _sd.items() if 'lora_' in k}\n"
+                "            _log(f'Extracted {len(_lora_sd)} LoRA params from state_dict')\n"
+                "            if _rank == 0:\n"
+                "                import os as _os\n"
+                "                from safetensors.torch import save_file as _sf\n"
+                "                _os.makedirs(meta.path, exist_ok=True)\n"
+                "                _sf(_lora_sd, _os.path.join(meta.path, 'adapter_model.safetensors'))\n"
+                "                self.model.peft_config['default'].save_pretrained(meta.path)\n"
+                "                self.model_config.save_pretrained(meta.path)\n"
+                "                _log(f'LoRA adapter saved to {meta.path}')\n"
+                "            dist.barrier(group=self.cpu_group)\n"
+                "            _log('LoRA save done')\n"
+                "        else:\n"
+                "            _log('Full model save via _save_model_to_hf')\n"
+                "            self._save_model_to_hf(meta.path, self.tokenizer, self.processor)\n"
+                "            _log('_save_model_to_hf done')\n"
+                "\n"
+                "        fut = Future()\n"
+                "\n"
+                "        if _rank == 0:\n"
+                "            _log('calling rollout_engine.update_weights_from_disk...')\n"
+                "            fut = self.rollout_engine.update_weights_from_disk(meta)\n"
+                "            _log('rollout_engine.update_weights_from_disk returned future')"
+            )
+            if old in content:
+                content = content.replace(old, new, 1)
+                with open(fsdp_engine, "w") as f:
+                    f.write(content)
+                patched.append("fsdp_engine.py: fixed disk weight sync (save-first + skip tokenizer)")
+            else:
+                print(f"  WARNING: Fix 4 patch target not found in {fsdp_engine}")
+                print(f"           Expected _update_weights_from_disk starting with 'fut = Future()'")
+                print(f"           Patch NOT applied — inspect manually.")
+
+    # Fix 6: Patch _save_model_to_hf to avoid safetensors storage_ptr crash for LoRA.
+    # FSDP2 get_model_state_dict returns valid CPU tensors, but model.save_pretrained
+    # calls safetensors._find_shared_tensors which accesses the MODEL's parameters
+    # (not the returned state_dict), hitting invalid storage from FSDP2 cpu_offload.
+    # Fix: use get_model_state_dict + filter LoRA keys + save_file directly.
+    if os.path.exists(fsdp_engine):
+        with open(fsdp_engine, "r") as f:
+            content = f.read()
+        if "# PATCHED: LoRA-aware save" not in content:
+            old_save = (
+                '        # save huggingface model on rank 0\n'
+                '        if dist.get_rank() == 0:\n'
+                '            os.makedirs(path, exist_ok=True)\n'
+                '            self.model.save_pretrained(path, state_dict=state_dict)\n'
+                '            self.model_config.save_pretrained(path)'
+            )
+            new_save = (
+                '        # PATCHED: LoRA-aware save — bypass model.save_pretrained for LoRA\n'
+                '        # save_pretrained calls safetensors._find_shared_tensors which accesses\n'
+                '        # FSDP2-offloaded model params → invalid storage crash.\n'
+                '        # Instead: save state_dict directly with safetensors.save_file.\n'
+                '        if dist.get_rank() == 0:\n'
+                '            os.makedirs(path, exist_ok=True)\n'
+                '            _is_lora = hasattr(self.model, "peft_config")\n'
+                '            if _is_lora:\n'
+                '                # Filter for LoRA adapter keys only\n'
+                '                _lora_sd = {k: v for k, v in state_dict.items() if "lora_" in k}\n'
+                '                from safetensors.torch import save_file as _sf\n'
+                '                _sf(_lora_sd, os.path.join(path, "adapter_model.safetensors"))\n'
+                '                self.model.peft_config["default"].save_pretrained(path)\n'
+                '            else:\n'
+                '                self.model.save_pretrained(path, state_dict=state_dict)\n'
+                '            self.model_config.save_pretrained(path)'
+            )
+            if old_save in content:
+                content = content.replace(old_save, new_save, 1)
+                with open(fsdp_engine, "w") as f:
+                    f.write(content)
+                patched.append("fsdp_engine.py: LoRA-aware _save_model_to_hf (bypass save_pretrained)")
+            else:
+                print(f"  WARNING: Fix 6 patch target not found in fsdp_engine.py")
+
+    # Fix 5: Add lora_target_modules field to SGLangConfig in cli_args.py
+    # Required by SGLang when enable_lora=True — without it, SGLang can't properly
+    # initialize the LoRA memory pool, causing silent hangs on first LoRA inference.
+    # Must be patched BEFORE AReaL imports cli_args (happens in PPOTrainer.__init__).
+    cli_args = os.path.join(areal_dir, "api", "cli_args.py")
+    if os.path.exists(cli_args):
+        with open(cli_args, "r") as f:
+            content = f.read()
+        if "lora_target_modules" not in content:
+            old = "    max_lora_rank: int | None = None"
+            new = (
+                "    max_lora_rank: int | None = None\n"
+                "    lora_target_modules: list[str] | None = None  # PATCHED: Fix 5"
+            )
+            if old in content:
+                content = content.replace(old, new, 1)
+                with open(cli_args, "w") as f:
+                    f.write(content)
+                patched.append("cli_args.py: added lora_target_modules to SGLangConfig")
+            else:
+                print(f"  WARNING: Fix 5 patch target not found in {cli_args}")
+                print(f"           Expected: max_lora_rank: int | None = None")
+
+    if patched:
+        for p in patched:
+            print(f"  Patched {p}")
+    else:
+        print("  SGLang LoRA patches: no patches applied (already applied or targets not found)")
+
+
+def _patch_pause_resume_diagnostic():
+    """Add logging to identify exactly where the rollout hangs after weight update.
+    Writes to both stdout and /mnt/job_stage/output/diag.log for retrieval."""
+    import glob as _g
+
+    areal_dirs = _g.glob("/opt/venv/snowbook/lib/python3.*/site-packages/areal/")
+    if not areal_dirs:
+        return
+    areal_dir = areal_dirs[0]
+
+    patched = []
+
+    # 1. Log Dispatcher.pause/resume state transitions
+    wfe = os.path.join(areal_dir, "infra", "workflow_executor.py")
+    if os.path.exists(wfe):
+        with open(wfe) as f:
+            content = f.read()
+        if "# DIAG: pause/resume" not in content:
+            old = ("    def pause(self):\n"
+                   "        self.runner.pause()\n"
+                   "        with self._input_cv:\n"
+                   "            self._input_cv.notify()")
+            new = ("    def pause(self):\n"
+                   "        import time as _t; _msg = f'[DIAG {_t.strftime(\"%H:%M:%S\")}] Dispatcher.pause() called'  # DIAG: pause/resume\n"
+                   "        print(_msg, flush=True)\n"
+                   "        with open('/mnt/job_stage/output/diag.log', 'a') as _df: _df.write(_msg + '\\n')\n"
+                   "        self.runner.pause()\n"
+                   "        _msg2 = f'[DIAG {_t.strftime(\"%H:%M:%S\")}] Dispatcher.pause() done, is_paused={self.runner.paused.is_set()}'\n"
+                   "        print(_msg2, flush=True)\n"
+                   "        with open('/mnt/job_stage/output/diag.log', 'a') as _df: _df.write(_msg2 + '\\n')\n"
+                   "        with self._input_cv:\n"
+                   "            self._input_cv.notify()")
+            old2 = ("    def resume(self):\n"
+                    "        self.runner.resume()\n"
+                    "        with self._input_cv:\n"
+                    "            self._input_cv.notify()")
+            new2 = ("    def resume(self):\n"
+                    "        import time as _t; _msg = f'[DIAG {_t.strftime(\"%H:%M:%S\")}] Dispatcher.resume() called, was_paused={self.runner.paused.is_set()}'  # DIAG: pause/resume\n"
+                    "        print(_msg, flush=True)\n"
+                    "        with open('/mnt/job_stage/output/diag.log', 'a') as _df: _df.write(_msg + '\\n')\n"
+                    "        self.runner.resume()\n"
+                    "        _msg2 = f'[DIAG {_t.strftime(\"%H:%M:%S\")}] Dispatcher.resume() done, is_paused={self.runner.paused.is_set()}'\n"
+                    "        print(_msg2, flush=True)\n"
+                    "        with open('/mnt/job_stage/output/diag.log', 'a') as _df: _df.write(_msg2 + '\\n')\n"
+                    "        with self._input_cv:\n"
+                    "            self._input_cv.notify()")
+            if old in content and old2 in content:
+                content = content.replace(old, new, 1).replace(old2, new2, 1)
+                with open(wfe, "w") as f:
+                    f.write(content)
+                patched.append("workflow_executor.py: pause/resume diagnostics")
+            else:
+                print(f"  WARNING: pause/resume patch targets not found in {wfe}")
+
+    # 2. Log agenerate pause loop
+    rie = os.path.join(areal_dir, "infra", "remote_inf_engine.py")
+    if os.path.exists(rie):
+        with open(rie) as f:
+            content = f.read()
+        if "# DIAG: agenerate" not in content:
+            old = ("            while self.workflow_executor.is_paused():\n"
+                   "                await asyncio.sleep(0.5)")
+            new = ("            _diag_cnt = 0\n"
+                   "            while self.workflow_executor.is_paused():\n"
+                   "                _diag_cnt += 1  # DIAG: agenerate\n"
+                   "                if _diag_cnt == 1 or _diag_cnt % 20 == 0:\n"
+                   "                    import time as _t; _msg = f'[DIAG {_t.strftime(\"%H:%M:%S\")}] agenerate paused for {_diag_cnt*0.5:.0f}s'\n"
+                   "                    print(_msg, flush=True)\n"
+                   "                    try:\n"
+                   "                        with open('/mnt/job_stage/output/diag.log', 'a') as _df: _df.write(_msg + '\\n')\n"
+                   "                    except Exception: pass\n"
+                   "                await asyncio.sleep(0.5)\n"
+                   "            if _diag_cnt > 0:\n"
+                   "                import time as _t; _msg = f'[DIAG {_t.strftime(\"%H:%M:%S\")}] agenerate resumed after {_diag_cnt*0.5:.0f}s'\n"
+                   "                print(_msg, flush=True)\n"
+                   "                try:\n"
+                   "                    with open('/mnt/job_stage/output/diag.log', 'a') as _df: _df.write(_msg + '\\n')\n"
+                   "                except Exception: pass")
+            if old in content:
+                content = content.replace(old, new, 1)
+                with open(rie, "w") as f:
+                    f.write(content)
+                patched.append("remote_inf_engine.py: agenerate diagnostics")
+            else:
+                print(f"  WARNING: agenerate pause loop not found in {rie}")
+
+    # 3. Log _update_weights_from_disk after our patch (name_resolve + fut.result)
+    fsdp = os.path.join(areal_dir, "engine", "fsdp_engine.py")
+    if os.path.exists(fsdp):
+        with open(fsdp) as f:
+            content = f.read()
+        if "# DIAG: post-update" not in content:
+            # Add tracing around name_resolve.add and fut.result()
+            old_nr = (
+                "        if dist.get_rank() == 0:\n"
+                "            update_name = names.update_weights_from_disk(\n"
+                "                self.config.experiment_name,\n"
+                "                self.config.trial_name,\n"
+                "                self.get_version(),\n"
+                "            )\n"
+                "            name_resolve.add(\n"
+                "                update_name, str(datetime.now().timestamp()), keepalive_ttl=120\n"
+                "            )\n"
+                "\n"
+                "            fut.result()\n"
+                "\n"
+                "        current_platform.synchronize()\n"
+                "        dist.barrier(group=self.cpu_group)"
+            )
+            new_nr = (
+                "        if dist.get_rank() == 0:  # DIAG: post-update\n"
+                "            _log('publishing name_resolve entry...')\n"
+                "            update_name = names.update_weights_from_disk(\n"
+                "                self.config.experiment_name,\n"
+                "                self.config.trial_name,\n"
+                "                self.get_version(),\n"
+                "            )\n"
+                "            name_resolve.add(\n"
+                "                update_name, str(datetime.now().timestamp()), keepalive_ttl=120\n"
+                "            )\n"
+                "            _log('name_resolve published, calling fut.result()...')\n"
+                "            fut.result()\n"
+                "            _log('fut.result() returned')\n"
+                "\n"
+                "        _log('calling current_platform.synchronize()...')\n"
+                "        current_platform.synchronize()\n"
+                "        _log('calling dist.barrier()...')\n"
+                "        dist.barrier(group=self.cpu_group)\n"
+                "        _log('_update_weights_from_disk EXIT')"
+            )
+            if old_nr in content:
+                content = content.replace(old_nr, new_nr, 1)
+                with open(fsdp, "w") as f:
+                    f.write(content)
+                patched.append("fsdp_engine.py: post-update diagnostics")
+            else:
+                print(f"  WARNING: post-update patch target not found in fsdp_engine.py")
+
+    if patched:
+        for p in patched:
+            print(f"  [diag] Patched {p}")
+    else:
+        print("  [diag] No diagnostic patches applied")
+
+
+def _patch_vllm_lora_xccl():
+    """Patch AReaL's vLLM LoRA xccl weight update to register adapter name.
+
+    The xccl path uses low-level _add_adapter/activate_adapter which only
+    registers by int ID, not by name. Generation requests use model="default_lora-vN"
+    which requires name registration in vLLM's serving layer. Without this patch,
+    the serving layer can't find the new LoRA name after each weight update.
+
+    Fix: After xccl weight update completes, call the serving layer's
+    load_lora_adapter to register the name (the actual weights are already loaded,
+    so this just does the name registration).
+    """
+    # Patch the server-side handler to register LoRA name after xccl update
+    for path in [
+        "/opt/venv/snowbook/lib/python3.12/site-packages/areal/engine/vllm_ext/areal_vllm_server.py",
+        "/opt/venv/snowbook/lib/python3.11/site-packages/areal/engine/vllm_ext/areal_vllm_server.py",
+    ]:
+        if not os.path.exists(path):
+            continue
+
+        with open(path, "r") as f:
+            content = f.read()
+
+        if "# PATCHED: register lora name after xccl" in content:
+            print("  areal_vllm_server.py already patched")
+            return
+
+        # The current xccl handler just calls the utility and returns:
+        #   ret_list = await llm.engine_core.call_utility_async(
+        #       "areal_injected_update_weight_lora_xccl",
+        #   )
+        #   return build_response(ret_list)
+        #
+        # We need to also register the LoRA name via the serving layer.
+        # The set_weight_meta_lora was called earlier, storing the name in
+        # raw_request.app.state — but we need the name. We'll store it
+        # during set_weight_meta_lora and retrieve it here.
+
+        # Step 1: Store lora_name in app state during set_weight_meta_lora
+        old_meta = 'async def set_weight_meta_xccl_lora(\n    request: UpdateWeightsFromXcclRequestLora, raw_request: Request\n):'
+        new_meta = (
+            'async def set_weight_meta_xccl_lora(\n'
+            '    request: UpdateWeightsFromXcclRequestLora, raw_request: Request\n'
+            '):\n'
+            '    # PATCHED: register lora name after xccl\n'
+            '    raw_request.app.state._areal_pending_lora_name = request.lora_name\n'
+            '    raw_request.app.state._areal_pending_lora_int_id = request.lora_int_id'
+        )
+        if old_meta in content:
+            content = content.replace(old_meta, new_meta, 1)
+
+        # Step 2: After xccl update, register the name
+        old_xccl = (
+            '@router.post("/areal_update_weights_lora_xccl")\n'
+            'async def update_weight_lora_xccl(raw_request: Request):\n'
+            '    logger.info("API server starts update_weight_lora via XCCL")\n'
+            '    llm = raw_request.app.state.engine_client\n'
+            '    ret_list = await llm.engine_core.call_utility_async(\n'
+            '        "areal_injected_update_weight_lora_xccl",\n'
+            '    )\n'
+            '    return build_response(ret_list)'
+        )
+        new_xccl = (
+            '@router.post("/areal_update_weights_lora_xccl")\n'
+            'async def update_weight_lora_xccl(raw_request: Request):\n'
+            '    logger.info("API server starts update_weight_lora via XCCL")\n'
+            '    llm = raw_request.app.state.engine_client\n'
+            '    ret_list = await llm.engine_core.call_utility_async(\n'
+            '        "areal_injected_update_weight_lora_xccl",\n'
+            '    )\n'
+            '    # PATCHED: register lora name after xccl update\n'
+            '    try:\n'
+            '        _lora_name = getattr(raw_request.app.state, "_areal_pending_lora_name", None)\n'
+            '        _lora_int_id = getattr(raw_request.app.state, "_areal_pending_lora_int_id", None)\n'
+            '        if _lora_name and hasattr(llm, "engine_client"):\n'
+            '            from vllm.lora.request import LoRARequest\n'
+            '            from vllm.entrypoints.openai.serving_models import OpenAIServingModels\n'
+            '            _serving = None\n'
+            '            for attr in ["chat", "completion", "serving_completion", "serving_chat"]:\n'
+            '                _s = getattr(raw_request.app.state, attr, None)\n'
+            '                if _s and hasattr(_s, "models"):\n'
+            '                    _serving = _s.models\n'
+            '                    break\n'
+            '            if _serving and hasattr(_serving, "lora_requests"):\n'
+            '                _serving.lora_requests.append(LoRARequest(\n'
+            '                    lora_name=_lora_name, lora_int_id=_lora_int_id, lora_path="/tmp/dummy"))\n'
+            '                logger.info(f"Registered LoRA name {_lora_name} in serving models")\n'
+            '            else:\n'
+            '                logger.info(f"Could not find serving models to register {_lora_name}")\n'
+            '    except Exception as _e:\n'
+            '        logger.warning(f"Failed to register LoRA name in serving: {_e}")\n'
+            '    return build_response(ret_list)'
+        )
+
+        if old_xccl in content:
+            content = content.replace(old_xccl, new_xccl, 1)
+            with open(path, "w") as f:
+                f.write(content)
+            print(f"  Patched areal_vllm_server.py: LoRA xccl name registration")
+            return
+        else:
+            print(f"  WARNING: Could not find xccl patch target in {path}")
+            return
+
+    print("  WARNING: areal_vllm_server.py not found")
+
+
 def _patch_reward_api():
     """Patch AReaL's AsyncRewardWrapper for native async + longer timeout."""
     for path in ["/opt/venv/snowbook/lib/python3.12/site-packages/areal/api/reward_api.py",
@@ -822,6 +1310,37 @@ def main():
     print("\n--- Patching reward_api.py ---")
     _patch_reward_api()
 
+    # 2b. Patch vLLM LoRA xccl (if using LoRA)
+    print("--- Patching vllm_worker_extension.py ---")
+    _patch_vllm_lora_xccl()
+
+    # 2c. Patch SGLang + LoRA compatibility
+    print("--- Patching SGLang LoRA ---")
+    _patch_sglang_lora()
+
+    # 2d. Patch pause/resume diagnostic logging
+    print("--- Patching pause/resume diagnostics ---")
+    _patch_pause_resume_diagnostic()
+
+    # Diagnostic: verify fsdp_engine patch applied
+    import glob as _g
+    _areal_dirs = _g.glob("/opt/venv/snowbook/lib/python3.*/site-packages/areal/")
+    if _areal_dirs:
+        _fsdp = os.path.join(_areal_dirs[0], "engine", "fsdp_engine.py")
+        if os.path.exists(_fsdp):
+            with open(_fsdp) as _f:
+                for _i, _line in enumerate(_f, 1):
+                    if "_update_weights_from_disk" in _line or ("_save_model_to_hf" in _line and "def " not in _line):
+                        print(f"  [diag] fsdp_engine.py:{_i}: {_line.rstrip()}")
+            # Check sentinel
+            with open(_fsdp) as _f:
+                _c = _f.read()
+            if "# PATCHED: save first, skip tokenizer for LoRA" in _c:
+                print("  [diag] Fix 4 (save-first + skip tokenizer) CONFIRMED applied")
+            else:
+                print("  [diag] WARNING: Fix 4 NOT found in fsdp_engine.py!")
+    sys.stdout.flush()
+
     # 3. Copy reward module to local filesystem
     REWARD_MODULE_DIR = "/tmp/reward_modules"
     stage_src = "/mnt/job_stage/app"
@@ -906,13 +1425,11 @@ def main():
     with PPOTrainer(
         config,
         train_dataset=train_dataset,
-        valid_dataset=valid_dataset,
+        valid_dataset=None,  # Disable eval to avoid eval_rollout.wait(timeout=None) hang with LoRA
     ) as trainer:
         trainer.train(
             workflow="areal.workflow.rlvr.RLVRWorkflow",
             workflow_kwargs=workflow_kwargs,
-            eval_workflow="areal.workflow.rlvr.RLVRWorkflow",
-            eval_workflow_kwargs=eval_workflow_kwargs,
         )
 
     print("\n" + "=" * 60)

--- a/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
+++ b/samples/ml/ml_jobs/rl_cookbook/medical_soap/src/run_medical_soap.py
@@ -50,36 +50,6 @@ if _venv_bin not in _path:
     os.environ["PATH"] = f"{_venv_bin}:{_path}"
     print(f"  PATH: prepended {_venv_bin}")
 
-# Fix LD_LIBRARY_PATH for CUDA libs installed via pip (cuDNN, cuBLAS, etc.)
-# The SPCS runtime installs nvidia-cudnn-cu12 etc. as pip packages which place
-# .so files in site-packages, but torch looks for them on LD_LIBRARY_PATH.
-# We set LD_LIBRARY_PATH AND preload libcudnn via ctypes (since LD_LIBRARY_PATH
-# changes after process start only affect dlopen with full path, not by name).
-import site
-import ctypes
-import glob as _glob
-_sp = site.getsitepackages()[0] if site.getsitepackages() else ""
-_nvidia_dirs = []
-if _sp:
-    for _pkg in ["nvidia/cudnn/lib", "nvidia/cublas/lib", "nvidia/cuda_runtime/lib",
-                 "nvidia/cuda_nvrtc/lib", "nvidia/cuda_cupti/lib", "nvidia/cufft/lib",
-                 "nvidia/curand/lib", "nvidia/cusolver/lib", "nvidia/cusparse/lib",
-                 "nvidia/nccl/lib", "nvidia/nvtx/lib", "nvidia/nvjitlink/lib"]:
-        _d = os.path.join(_sp, _pkg)
-        if os.path.isdir(_d):
-            _nvidia_dirs.append(_d)
-if _nvidia_dirs:
-    _existing = os.environ.get("LD_LIBRARY_PATH", "")
-    os.environ["LD_LIBRARY_PATH"] = ":".join(_nvidia_dirs) + (":" + _existing if _existing else "")
-    # Preload critical .so files so dlopen can find them by name
-    for _d in _nvidia_dirs:
-        for _so in sorted(_glob.glob(os.path.join(_d, "*.so*"))):
-            try:
-                ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)
-            except OSError:
-                pass
-    print(f"  CUDA libs: preloaded from {len(_nvidia_dirs)} nvidia pip dirs")
-
 # Install AReaL and vLLM with --no-deps to avoid torch reinstall.
 print("--- Installing AReaL + vLLM (--no-deps) ---")
 subprocess.check_call([


### PR DESCRIPTION
## Summary
- Adds `rl_cookbook/medical_soap/` — an RL training pipeline that trains Qwen3-1.7B to generate structured medical SOAP notes from doctor-patient dialogues
- Uses GRPO with a decomposed reward function (format check + per-section LLM judge via Qwen3-8B)
- The RL-trained 1.7B model outperforms the 235B base model on all evaluation metrics (S, O, A, P sections + JSON validity)
- Runs on SPCS managed runtime via ML Jobs `submit_directory()` with checkpoints saved directly to Snowflake stage

## What's included
- `src/run_medical_soap.py` — Training entrypoint with SPCS runtime fixes, GPU layout (6 AReaL + 2 judge), async reward function
- `src/eval_medical_soap.py` — Eval pipeline with local Qwen3-8B vLLM judge on SPCS
- `src/config.yaml` — AReaL training config (GRPO, 10 epochs, batch_size=128)
- `src/prompt_utils.py` — System prompts and judge prompt templates
- `src/reward.py` — JSON extraction and SOAP validation utilities
- `scripts/` — Job submission scripts (train, eval, data prep)

## Test plan
- [x] Training job runs successfully on SPCS (10 epochs, ~20h on 8x L4 GPUs)
- [x] Eval job completes with results captured in event table
- [x] Base model eval: Qwen3-1.7B scores 3.15/5.0 on 20 test samples

## Note
The vLLM wheel (`vllm-0.14.0-*.whl`, ~473MB) is excluded from the repo due to size. It must be downloaded separately and placed in `src/` before submitting training jobs.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)