### PR TITLE
Add Meta Conversions API (CAPI) pipeline skill for Cortex Code

### DIFF
--- a/samples/meta-capi-pipeline/.gitignore
+++ b/samples/meta-capi-pipeline/.gitignore
@@ -1,0 +1,6 @@
+# Ignore
+.DS_Store
+*.pyc
+__pycache__/
+.env
+*.log

--- a/samples/meta-capi-pipeline/LICENSE
+++ b/samples/meta-capi-pipeline/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, "Skills")) is governed as Client Software by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake's Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/).
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills, except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills;
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor,
+* Reverse engineer, decompile, or disassemble the Skills.
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED "AS IS," WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/samples/meta-capi-pipeline/README.md
+++ b/samples/meta-capi-pipeline/README.md
@@ -1,0 +1,110 @@
+# Meta CAPI Skill for Cortex Code
+
+A Cortex Code skill that builds and manages Meta Conversions API (CAPI) pipelines in Snowflake.
+
+## Features
+
+- **Natural Language Triggers**: "set up Meta CAPI", "discover tables", "get recommendations"
+- **Human-in-the-Loop**: All pipeline deployments require explicit approval
+- **Auto-Discovery**: Scans your tables to find CAPI-compatible event sources
+- **Meta AI Recommendations**: Fetches signal recommendations from Meta's Use Case API
+- **CDC Pipelines**: Automatic change data capture from source tables
+- **PII Hashing**: SHA256 hashing of emails/phones before transmission
+
+## Installation
+
+### Option 1: Clone to Skills Directory
+
+```bash
+# Navigate to Cortex Code skills directory
+cd ~/.snowflake/cortex/skills
+
+# Clone this repo
+git clone https://github.com/sfc-gh-vakumar/meta-enhanced-capi.git
+```
+
+### Option 2: Symlink (for development)
+
+```bash
+# Clone anywhere
+git clone https://github.com/sfc-gh-vakumar/meta-enhanced-capi.git ~/projects/meta-enhanced-capi
+
+# Symlink to skills directory
+ln -s ~/projects/meta-enhanced-capi ~/.snowflake/cortex/skills/meta-enhanced-capi
+```
+
+### Verify Installation
+
+In Cortex Code, run:
+```
+/skills
+```
+
+You should see `meta-enhanced-capi` listed.
+
+## Usage
+
+### Trigger Phrases
+
+| Say this... | To do this... |
+|-------------|---------------|
+| "set up Meta CAPI" | Create pipeline infrastructure |
+| "discover tables for Meta" | Find CAPI-compatible tables |
+| "get signal recommendations" | Fetch Meta AI recommendations |
+| "run CAPI pipeline" | Process pending events |
+| "check CAPI status" | View pipeline health |
+| "debug CAPI" | Troubleshoot failures |
+
+### Example Workflow
+
+```
+You: set up Meta CAPI
+
+Cortex Code: I'll create the Meta CAPI pipeline infrastructure.
+Please provide:
+- Pixel ID: [from Meta Events Manager]
+- Access Token: [with ads_management permission]
+...
+```
+
+## Prerequisites
+
+Your use of Meta Conversions API (CAPI) is governed by your agreements with Meta.
+
+Before using this skill, ensure you have:
+
+- [ ] **Snowflake**: ACCOUNTADMIN or CREATE INTEGRATION privilege
+- [ ] **Meta Pixel ID**: From [Meta Events Manager](https://business.facebook.com/events_manager)
+- [ ] **Meta Access Token**: With `ads_management` permission
+- [ ] **Warehouse**: For task execution (e.g., `COMPUTE_WH`)
+
+## Skill Structure
+
+```
+meta-enhanced-capi/
+├── SKILL.md                 # Main skill definition
+├── README.md                # This file
+├── references/
+│   └── meta_events.md       # Meta standard events reference
+└── sql/
+    ├── 00_discovery/        # Table discovery & pipeline config
+    ├── 01_setup/            # Schema & network access
+    ├── 02_processing/       # UDTF & procedures
+    ├── 03_monitoring/       # Health checks & alerts
+    ├── 04_troubleshooting/  # Validation & error handling
+    └── 05_recommendations/  # Meta Use Case API integration
+```
+
+## Objects Created
+
+| Object | Type | Purpose |
+|--------|------|---------|
+| `META_CAPI_DB.PIPELINE` | Schema | Container for all objects |
+| `META_CAPI_EVENTS` | Table | Event staging (PENDING → SENT) |
+| `META_CAPI_LOG` | Table | Batch processing logs |
+| `send_to_meta_capi` | UDTF | Calls Meta Graph API |
+| `meta_capi_integration` | Integration | External network access |
+
+## License
+
+MIT

--- a/samples/meta-capi-pipeline/SKILL.md
+++ b/samples/meta-capi-pipeline/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: meta-capi-pipeline
+description: "Build and manage Meta Conversions API (CAPI) pipelines in Snowflake. Triggers: set up Meta CAPI, create CAPI pipeline, discover tables, find CAPI candidates, get signal recommendations, run pipeline, send events to Meta, check CAPI status, pipeline health, debug CAPI, CAPI errors, resend failed events."
+---
+
+# Meta CAPI Pipeline
+
+Build and manage Meta Conversions API pipelines in Snowflake with human-in-the-loop approval workflows.
+
+## CRITICAL RULES — DO NOT SKIP
+
+> ⛔ THESE RULES ARE NON-NEGOTIABLE. VIOLATING ANY RULE IS A PIPELINE FAILURE.
+
+1. **PII hashing is MANDATORY.** All PII fields (email, phone, name, city, state, zip) MUST be SHA256-hashed. The pipeline generator handles this automatically — never send unhashed PII.
+2. **DISCOVERY GATE: You MUST ask the user which column to use as `event_id`** for deduplication BEFORE presenting any approval prompt. Do NOT auto-generate without asking. Do NOT skip this question.
+3. **DISCOVERY GATE: You MUST ask the user about custom fields** — ask if they want to include any additional custom fields in `custom_data` BEFORE presenting any approval prompt. No need to list all unmapped columns; a simple question is sufficient.
+4. **Never deploy a pipeline without explicit user approval** on the final config.
+5. **The Discovery flow has THREE mandatory stops** (table selection → event_id + custom fields → approval). You CANNOT compress these into fewer stops.
+
+## Prerequisites
+
+- ACCOUNTADMIN or CREATE INTEGRATION privilege
+- Meta Pixel ID (from Events Manager)
+- Meta Access Token (with `ads_management` permission)
+- PII must be pre-hashed (SHA256, lowercase, trimmed) — handled automatically by mapping views
+
+## Schema Design
+
+`META_CAPI_EVENTS` uses a flexible VARIANT schema:
+- **Fixed columns**: EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, EVENT_SOURCE_URL
+- **`USER_DATA` (VARIANT)**: em, ph, fn, ln, ct, st, zp, country, external_id, client_ip_address, fbc, fbp, + any future fields
+- **`CUSTOM_DATA` (VARIANT)**: value, currency, content_ids, order_id, search_string, predicted_ltv, + any custom/future fields
+
+This means new Meta fields or custom parameters never require table DDL changes — just update the mapping view.
+
+## Intent Detection
+
+| Intent | Triggers | Action |
+|--------|----------|--------|
+| **Setup** | "set up Meta CAPI", "create CAPI pipeline", "install CAPI" | → Step 1: Setup |
+| **Discover** | "discover tables", "find CAPI candidates", "scan for Meta data" | → Step 2: Discovery |
+| **Recommend** | "get signal recommendations", "what events should I send" | → Step 3: Recommendations |
+| **Run** | "run pipeline", "send events to Meta", "process pending" | → Step 4: Processing |
+| **Monitor** | "check CAPI status", "pipeline health", "view Meta events" | → Step 5: Monitoring |
+| **Troubleshoot** | "debug CAPI", "CAPI errors", "resend failed events" | → Step 6: Troubleshooting |
+
+## Workflow
+
+### Step 1: Setup (01_setup)
+
+**Goal:** Create infrastructure for Meta CAPI integration.
+
+**Actions:**
+
+1. **Ask** user for credentials:
+   ```
+   Please provide:
+   - Pixel ID: [from Meta Events Manager]
+   - Access Token: [with ads_management permission]
+   - Warehouse: [for task execution]
+   ```
+
+2. **Execute** schema creation:
+   ```sql
+   CREATE DATABASE IF NOT EXISTS META_CAPI_DB;
+   CREATE SCHEMA IF NOT EXISTS META_CAPI_DB.PIPELINE;
+   ```
+
+3. **Execute** table creation (META_CAPI_EVENTS, META_CAPI_LOG, META_CAPI_CONFIG)
+
+4. **Execute** network access setup:
+   ```sql
+   CREATE SECRET meta_capi_access_token TYPE = GENERIC_STRING SECRET_STRING = '<TOKEN>';
+   CREATE NETWORK RULE meta_capi_network_rule MODE = EGRESS TYPE = HOST_PORT VALUE_LIST = ('graph.facebook.com:443', 'api.facebook.com:443');
+   CREATE EXTERNAL ACCESS INTEGRATION meta_capi_integration ALLOWED_NETWORK_RULES = (meta_capi_network_rule) ALLOWED_AUTHENTICATION_SECRETS = (meta_capi_access_token) ENABLED = TRUE;
+   ```
+
+5. **Execute** UDTF and procedure creation
+
+6. **Execute** task creation for scheduled processing
+
+**Output:** Fully configured META_CAPI_DB.PIPELINE schema with all objects.
+
+---
+
+### Step 2: Discovery (00_discovery)
+
+**Goal:** Find candidate tables and generate pipeline configs for human review.
+
+> ⛔ THIS STEP HAS THREE MANDATORY STOPS. YOU MUST COMPLETE ALL THREE IN ORDER.
+> STOP A → Table selection
+> STOP B → Event ID + Custom fields (DO NOT offer approval here)
+> STOP C → Final approval
+
+---
+
+#### Step 2A: Scan & Select Tables
+
+1. **Ask** user for scope:
+   ```
+   Where should I look for event data?
+   - Database: [optional, default: all accessible]
+   - Schema: [optional, default: all schemas]
+   ```
+
+2. **Execute** table discovery:
+   ```sql
+   CALL discover_capi_candidate_tables('<DATABASE>', '<SCHEMA>');
+   ```
+
+3. **Present** candidates with match scores (EXCELLENT/GOOD/MODERATE)
+
+4. **⚠️ STOP A**: Ask user to select table(s) for pipeline creation. **Wait for response.**
+
+---
+
+#### Step 2B: Event ID & Custom Fields (MANDATORY — DO NOT SKIP)
+
+> ⛔ YOU MUST COMPLETE THIS STEP. DO NOT JUMP TO APPROVAL.
+> If you find yourself about to show "Do you approve?" without having asked about event_id and custom fields, STOP and come back here.
+
+5. **Execute** config generation:
+   ```sql
+   CALL generate_pipeline_config('<DB>', '<SCHEMA>', '<TABLE>', '<EVENT_TYPE>', '<ACTION_SOURCE>');
+   ```
+
+6. **Present** the auto-mapped config (show which columns were mapped to which Meta fields).
+
+7. **In the SAME message**, ask BOTH of these questions:
+
+   ```
+   Before I finalize this config, I need two inputs from you:
+
+   1. EVENT ID (Deduplication): Which column should be used as event_id?
+      Meta uses this to deduplicate events across sources (pixel, server, app).
+      Candidate columns from your table: [list ID-like columns: order_id, transaction_id, lead_id, etc.]
+      Or choose "auto" to auto-generate unique IDs (no deduplication).
+
+   2. CUSTOM FIELDS: Would you like to include any additional columns as
+      custom_data fields? They'll be available for custom audiences and
+      optimization signals in Meta Ads Manager.
+      If yes, list the column names. Otherwise, say "none".
+   ```
+
+8. **⚠️ STOP B**: **STOP HERE. DO NOT show approval options. DO NOT offer to deploy. Wait for user response.**
+
+---
+
+#### Step 2C: Final Config & Approval
+
+> You may ONLY reach this step AFTER receiving answers to Step 2B.
+
+9. **Incorporate** user answers into the config:
+   - Set `column_mapping.event_id` to the user's chosen column (or leave as auto-generate)
+   - Add user-selected columns to `column_mapping.custom_fields`
+
+10. **Present** the FINAL config summary:
+    ```
+    Final pipeline config:
+    - Event type: [X]
+    - Event ID column: [X or auto-generated]
+    - PII fields (auto-hashed): [list]
+    - Standard fields: [value, currency, order_id, etc.]
+    - Custom fields: [user-selected or none]
+    - Action source: [website/app/etc.]
+
+    Do you approve this config for deployment? (Yes/No/Edit)
+    ```
+
+11. **⚠️ STOP C**: Wait for approval.
+
+12. **If approved**, execute deployment:
+    ```sql
+    CALL save_pipeline_config(<config>, '<name>');
+    CALL approve_pipeline_config('<config_id>', '<approval_notes>');
+    CALL deploy_pipeline_from_config('<config_id>');
+    ```
+
+**Output:** Deployed CDC pipeline (stream + view + task) loading to META_CAPI_EVENTS.
+
+---
+
+#### Discovery Completion Checklist
+
+Before deploying ANY pipeline, verify:
+- [ ] User selected source table(s) — **STOP A complete**
+- [ ] User specified event_id column (or chose "auto") — **STOP B complete**
+- [ ] User was asked about custom fields and confirmed (or "none") — **STOP B complete**
+- [ ] User explicitly approved final config — **STOP C complete**
+
+If ANY box is unchecked, DO NOT DEPLOY.
+
+---
+
+### Step 3: Recommendations (05_recommendations)
+
+**Goal:** Fetch Meta AI recommendations and implement with human approval.
+
+**Actions:**
+
+1. **Retrieve** Pixel ID from config (already provided during Setup):
+   ```sql
+   SELECT CONFIG_VALUE FROM META_CAPI_DB.PIPELINE.META_CAPI_CONFIG WHERE CONFIG_KEY = 'pixel_id';
+   ```
+
+2. **Execute** recommendation fetch using Pixel ID as data_source_id:
+   ```sql
+   CALL get_use_case_recommendations(data_source_id => '<PIXEL_ID>');
+   ```
+
+3. **Present** recommendations (Online Purchase, Lead Gen, pLTV, etc.)
+
+4. **⚠️ MANDATORY STOPPING POINT**: Ask user which recommendation to implement.
+
+5. **Execute** table discovery for selected recommendation:
+   ```sql
+   CALL discover_tables_for_recommendations('<DATABASE>', '<SCHEMA>');
+   ```
+
+6. **Present** matching tables with fit assessment.
+
+7. **⚠️ MANDATORY STOPPING POINT**: Get table selection from user.
+
+8. **Execute** config generation:
+   ```sql
+   CALL generate_reco_config('<use_case>', '<DB>', '<SCHEMA>', '<TABLE>');
+   ```
+
+9. **Present** config with Meta requirements and column mappings.
+
+10. **Ask event_id and custom fields questions** (same as Step 2B above). Wait for response.
+
+11. **⚠️ MANDATORY STOPPING POINT**: Present final config, get explicit approval.
+    ```
+    Review the config above. Do you approve? (Yes/No/Edit)
+    ```
+
+12. **If approved**, execute deployment:
+    ```sql
+    CALL save_reco_config(<config>, '<name>');
+    CALL approve_reco_config('<config_id>', '<approval_notes>');
+    CALL deploy_reco_config('<config_id>');
+    ```
+
+**Output:** Deployed RECO_* pipeline objects (stream + view + task).
+
+---
+
+### Step 4: Processing (02_processing)
+
+**Goal:** Send pending events to Meta Graph API.
+
+**Actions:**
+
+1. **Execute** manual processing:
+   ```sql
+   CALL process_pending_capi_events('<PIXEL_ID>');
+   ```
+
+2. **Or** check task status:
+   ```sql
+   SHOW TASKS LIKE 'meta_capi_task' IN SCHEMA META_CAPI_DB.PIPELINE;
+   ```
+
+3. **Present** results (events_received count, any failures).
+
+**Output:** Events sent to Meta, STATUS updated to SENT or FAILED.
+
+---
+
+### Step 5: Monitoring (03_monitoring)
+
+**Goal:** Check pipeline health and event delivery status.
+
+**Actions:**
+
+1. **Execute** health check:
+   ```sql
+   CALL capi_health_check();
+   ```
+
+2. **Present** health summary:
+   - Pending events count
+   - Success rate (24h)
+   - Failed events count
+   - Task state
+   - Last batch time
+
+3. **If issues detected**, suggest troubleshooting steps.
+
+**Output:** Health report with actionable recommendations.
+
+---
+
+### Step 6: Troubleshooting (04_troubleshooting)
+
+**Goal:** Diagnose and fix pipeline issues.
+
+**Actions:**
+
+1. **Execute** validation check:
+   ```sql
+   SELECT * FROM V_CAPI_VALIDATION WHERE VALIDATION_STATUS != 'VALID';
+   ```
+
+2. **Execute** error analysis:
+   ```sql
+   SELECT EVENT_ID, ERROR_MESSAGE, META_RESPONSE 
+   FROM META_CAPI_EVENTS WHERE STATUS = 'FAILED' 
+   ORDER BY PROCESSED_AT DESC LIMIT 20;
+   ```
+
+3. **Present** findings with error codes:
+   | Error | Cause | Solution |
+   |-------|-------|----------|
+   | 190 | Invalid token | Regenerate access token |
+   | 100 | Invalid parameter | Check payload format |
+   | 803 | Rate limited | Reduce batch frequency |
+
+4. **⚠️ MANDATORY STOPPING POINT**: Ask user before retry.
+   ```
+   Found X failed events. Reset them for retry? (Yes/No)
+   ```
+
+5. **If approved**, execute retry:
+   ```sql
+   CALL resend_failed_events(3, 1000);
+   ```
+
+**Output:** Failed events reset to PENDING for reprocessing.
+
+---
+
+## Stopping Points Summary
+
+| Step | Stop | Gate | What to ask |
+|------|------|------|-------------|
+| Discovery | **A** | Table selection | "Which table(s) do you want to set up?" |
+| Discovery | **B** | Event ID + Custom fields | "Which column for event_id?" + "Include any unmapped columns?" |
+| Discovery | **C** | Final approval | "Do you approve this config?" |
+| Recommendations | 1 | Use case selection | "Which recommendation to implement?" |
+| Recommendations | 2 | Table selection | "Which table fits this use case?" |
+| Recommendations | 3 | Event ID + Custom fields | Same as Discovery Stop B |
+| Recommendations | 4 | Final approval | "Do you approve?" |
+| Troubleshooting | 1 | Retry confirmation | "Reset X failed events for retry?" |
+
+**Resume rule:** Upon user approval ("yes", "approved", "proceed"), continue to next step without re-asking.
+
+## Objects Created
+
+| Object | Type | Purpose |
+|--------|------|---------|
+| `META_CAPI_DB.PIPELINE` | Schema | Container for all objects |
+| `META_CAPI_EVENTS` | Table | Event staging (flexible VARIANT schema) |
+| `META_CAPI_LOG` | Table | Batch processing logs |
+| `META_CAPI_CONFIG` | Table | Configuration storage |
+| `PIPELINE_CONFIGS` | Table | Discovery pipeline configs |
+| `META_CAPI_RECOMMENDATIONS` | Table | Meta API recommendations |
+| `META_RECO_CONFIGS` | Table | Recommendation configs |
+| `send_to_meta_capi` | UDTF | Calls Meta Graph API (pass-through) |
+| `meta_capi_access_token` | Secret | API credentials |
+| `meta_capi_network_rule` | Network Rule | Egress (graph + api.facebook.com) |
+| `meta_capi_integration` | Integration | External access |
+
+## Output
+
+- Configured Meta CAPI pipeline in Snowflake
+- CDC streams loading events from source tables
+- Scheduled task processing events hourly
+- Health monitoring and alerting

--- a/samples/meta-capi-pipeline/references/meta_events.md
+++ b/samples/meta-capi-pipeline/references/meta_events.md
@@ -1,0 +1,74 @@
+# Meta Standard Events Reference
+
+## Supported Events (17 Total)
+
+| Event Name | Description | Required Fields |
+|------------|-------------|-----------------|
+| `AddPaymentInfo` | Payment info added during checkout | event_time, user_data |
+| `AddToCart` | Item added to shopping cart | event_time, user_data, value, currency |
+| `AddToWishlist` | Item added to wishlist | event_time, user_data |
+| `CompleteRegistration` | User registration completed | event_time, user_data |
+| `Contact` | Contact form submitted | event_time, user_data |
+| `CustomizeProduct` | Product customization | event_time, user_data |
+| `Donate` | Donation made | event_time, user_data, value, currency |
+| `FindLocation` | Store locator used | event_time, user_data |
+| `InitiateCheckout` | Checkout process started | event_time, user_data, value, currency |
+| `Lead` | Lead form submitted | event_time, user_data |
+| `PageView` | Page viewed | event_time, user_data |
+| `Purchase` | Purchase completed | event_time, user_data, value, currency |
+| `Schedule` | Appointment scheduled | event_time, user_data |
+| `Search` | Search performed | event_time, user_data, search_string |
+| `StartTrial` | Free trial started | event_time, user_data |
+| `SubmitApplication` | Application submitted | event_time, user_data |
+| `Subscribe` | Subscription started | event_time, user_data, value, currency |
+| `ViewContent` | Content viewed | event_time, user_data |
+
+## User Data Fields (PII)
+
+All PII must be **SHA256 hashed** before sending.
+
+| Field | Description | Format |
+|-------|-------------|--------|
+| `em` | Email address | SHA256(lowercase(trim(email))) |
+| `ph` | Phone number | SHA256(digits only, with country code) |
+| `fn` | First name | SHA256(lowercase(trim(name))) |
+| `ln` | Last name | SHA256(lowercase(trim(name))) |
+| `ct` | City | SHA256(lowercase(trim(city))) |
+| `st` | State | SHA256(2-letter code) |
+| `zp` | Zip code | SHA256(first 5 digits) |
+| `country` | Country | 2-letter ISO code (not hashed) |
+| `external_id` | Customer ID | SHA256(id) |
+
+## Non-PII Fields
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `client_ip_address` | User's IP | `192.168.1.1` |
+| `client_user_agent` | Browser UA | `Mozilla/5.0...` |
+| `fbc` | Click ID cookie | `fb.1.1554763741205...` |
+| `fbp` | Browser ID cookie | `fb.1.1558571054389...` |
+
+## Custom Data Fields
+
+| Field | Description | Type |
+|-------|-------------|------|
+| `value` | Monetary value | Float |
+| `currency` | Currency code | String (ISO 4217) |
+| `content_ids` | Product SKUs | Array of strings |
+| `content_name` | Product name | String |
+| `content_type` | Product category | String |
+| `contents` | Product details | Array of objects |
+| `num_items` | Quantity | Integer |
+| `search_string` | Search query | String |
+
+## Action Sources
+
+| Value | Description |
+|-------|-------------|
+| `website` | Browser-based events |
+| `app` | Mobile app events |
+| `phone_call` | Phone call conversions |
+| `chat` | Chat/messaging conversions |
+| `physical_store` | In-store conversions |
+| `system_generated` | Automated/backend events |
+| `other` | Other sources |

--- a/samples/meta-capi-pipeline/sql/00_discovery/discover_tables.sql
+++ b/samples/meta-capi-pipeline/sql/00_discovery/discover_tables.sql
@@ -1,0 +1,160 @@
+-- =============================================================================
+-- META CAPI DISCOVERY MODULE
+-- Identifies candidate tables and maps columns to Meta event schema
+-- =============================================================================
+
+USE DATABASE META_CAPI_DB;
+USE SCHEMA PIPELINE;
+
+-- =============================================================================
+-- DISCOVER CANDIDATE TABLES
+-- Scans a target database/schema for tables with columns matching Meta event fields
+-- Uses IDENTIFIER() to dynamically query the correct INFORMATION_SCHEMA
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE DISCOVER_CAPI_CANDIDATE_TABLES(
+    TARGET_DATABASE VARCHAR,
+    TARGET_SCHEMA VARCHAR
+)
+RETURNS TABLE (
+    TABLE_CATALOG VARCHAR,
+    TABLE_SCHEMA VARCHAR,
+    TABLE_NAME VARCHAR,
+    ROW_COUNT NUMBER,
+    MATCH_SCORE VARCHAR,
+    MATCHED_COLUMNS VARCHAR,
+    SUGGESTED_EVENT_TYPE VARCHAR
+)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+    columns_table VARCHAR;
+    tables_table VARCHAR;
+BEGIN
+    columns_table := :TARGET_DATABASE || '.INFORMATION_SCHEMA.COLUMNS';
+    tables_table := :TARGET_DATABASE || '.INFORMATION_SCHEMA.TABLES';
+    
+    res := (
+        SELECT 
+            c.TABLE_CATALOG,
+            c.TABLE_SCHEMA,
+            c.TABLE_NAME,
+            t.ROW_COUNT,
+            CASE 
+                WHEN SUM(CASE WHEN LOWER(c.COLUMN_NAME) IN ('email', 'em', 'hashed_email', 'email_hash') THEN 1 ELSE 0 END) > 0
+                     AND SUM(CASE WHEN LOWER(c.COLUMN_NAME) IN ('event_time', 'timestamp', 'created_at', 'order_date', 'purchase_date') THEN 1 ELSE 0 END) > 0
+                     AND SUM(CASE WHEN LOWER(c.COLUMN_NAME) IN ('value', 'revenue', 'total', 'amount', 'order_total', 'price') THEN 1 ELSE 0 END) > 0
+                THEN 'EXCELLENT'
+                WHEN SUM(CASE WHEN LOWER(c.COLUMN_NAME) IN ('email', 'em', 'hashed_email', 'phone', 'ph') THEN 1 ELSE 0 END) > 0
+                     AND SUM(CASE WHEN LOWER(c.COLUMN_NAME) IN ('event_time', 'timestamp', 'created_at', 'order_date') THEN 1 ELSE 0 END) > 0
+                THEN 'GOOD'
+                WHEN SUM(CASE WHEN LOWER(c.COLUMN_NAME) IN ('email', 'em', 'hashed_email', 'phone', 'first_name', 'last_name') THEN 1 ELSE 0 END) > 0
+                THEN 'MODERATE'
+                ELSE 'LOW'
+            END AS MATCH_SCORE,
+            LISTAGG(
+                CASE WHEN LOWER(c.COLUMN_NAME) IN (
+                    'email', 'em', 'hashed_email', 'email_hash', 'phone', 'ph',
+                    'first_name', 'fn', 'last_name', 'ln', 'zip', 'zp', 'city', 'ct',
+                    'state', 'st', 'country', 'value', 'revenue', 'total', 'amount',
+                    'currency', 'order_id', 'event_time', 'timestamp', 'created_at',
+                    'order_date', 'purchase_date', 'event_name', 'action_source'
+                ) THEN c.COLUMN_NAME END,
+                ', '
+            ) AS MATCHED_COLUMNS,
+            CASE
+                WHEN SUM(CASE WHEN LOWER(c.COLUMN_NAME) IN ('value', 'revenue', 'total', 'amount', 'order_total') THEN 1 ELSE 0 END) > 0
+                THEN 'Purchase'
+                WHEN SUM(CASE WHEN LOWER(c.COLUMN_NAME) LIKE '%lead%' OR LOWER(c.COLUMN_NAME) LIKE '%signup%' THEN 1 ELSE 0 END) > 0
+                THEN 'Lead'
+                ELSE 'ViewContent'
+            END AS SUGGESTED_EVENT_TYPE
+        FROM IDENTIFIER(:columns_table) c
+        JOIN IDENTIFIER(:tables_table) t
+            ON c.TABLE_CATALOG = t.TABLE_CATALOG
+            AND c.TABLE_SCHEMA = t.TABLE_SCHEMA
+            AND c.TABLE_NAME = t.TABLE_NAME
+        WHERE c.TABLE_SCHEMA = :TARGET_SCHEMA
+            AND t.TABLE_TYPE = 'BASE TABLE'
+        GROUP BY c.TABLE_CATALOG, c.TABLE_SCHEMA, c.TABLE_NAME, t.ROW_COUNT
+        HAVING MATCH_SCORE IN ('EXCELLENT', 'GOOD', 'MODERATE')
+        ORDER BY 
+            CASE MATCH_SCORE 
+                WHEN 'EXCELLENT' THEN 1 
+                WHEN 'GOOD' THEN 2 
+                WHEN 'MODERATE' THEN 3 
+            END
+    );
+    RETURN TABLE(res);
+END;
+$$;
+
+-- =============================================================================
+-- ANALYZE TABLE MAPPING
+-- Deep analysis of a specific table for Meta event mapping
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE analyze_table_mapping(
+    source_database VARCHAR,
+    source_schema VARCHAR,
+    source_table VARCHAR
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    result VARIANT;
+    col_mappings VARIANT;
+    columns_ref VARCHAR;
+BEGIN
+    columns_ref := :source_database || '.INFORMATION_SCHEMA.COLUMNS';
+    
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(
+        'source_column', COLUMN_NAME,
+        'data_type', DATA_TYPE,
+        'suggested_target', 
+        CASE 
+            WHEN LOWER(COLUMN_NAME) LIKE '%email%' OR LOWER(COLUMN_NAME) = 'em' THEN 'EM (email hash)'
+            WHEN LOWER(COLUMN_NAME) LIKE '%phone%' OR LOWER(COLUMN_NAME) = 'ph' THEN 'PH (phone hash)'
+            WHEN LOWER(COLUMN_NAME) LIKE '%first%name%' OR LOWER(COLUMN_NAME) = 'fn' THEN 'FN (first name hash)'
+            WHEN LOWER(COLUMN_NAME) LIKE '%last%name%' OR LOWER(COLUMN_NAME) = 'ln' THEN 'LN (last name hash)'
+            WHEN LOWER(COLUMN_NAME) LIKE '%amount%' OR LOWER(COLUMN_NAME) LIKE '%value%' OR LOWER(COLUMN_NAME) LIKE '%total%' THEN 'VALUE'
+            WHEN LOWER(COLUMN_NAME) LIKE '%currency%' THEN 'CURRENCY'
+            WHEN LOWER(COLUMN_NAME) LIKE '%event%' OR LOWER(COLUMN_NAME) LIKE '%action%' THEN 'EVENT_NAME'
+            WHEN LOWER(COLUMN_NAME) LIKE '%time%' OR LOWER(COLUMN_NAME) LIKE '%date%' OR LOWER(COLUMN_NAME) LIKE '%created%' THEN 'EVENT_TIME'
+            WHEN LOWER(COLUMN_NAME) LIKE '%order%id%' THEN 'ORDER_ID'
+            WHEN LOWER(COLUMN_NAME) LIKE '%user%id%' OR LOWER(COLUMN_NAME) LIKE '%customer%id%' THEN 'EXTERNAL_ID'
+            WHEN LOWER(COLUMN_NAME) LIKE '%ip%' THEN 'CLIENT_IP_ADDRESS'
+            WHEN LOWER(COLUMN_NAME) LIKE '%agent%' OR LOWER(COLUMN_NAME) LIKE '%browser%' THEN 'CLIENT_USER_AGENT'
+            WHEN LOWER(COLUMN_NAME) LIKE '%city%' THEN 'CT (city hash)'
+            WHEN LOWER(COLUMN_NAME) LIKE '%state%' THEN 'ST (state hash)'
+            WHEN LOWER(COLUMN_NAME) LIKE '%zip%' OR LOWER(COLUMN_NAME) LIKE '%postal%' THEN 'ZP (zip hash)'
+            WHEN LOWER(COLUMN_NAME) LIKE '%country%' THEN 'COUNTRY'
+            ELSE 'UNMAPPED'
+        END,
+        'requires_hashing', 
+        CASE 
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%phone%', '%first%', '%last%', '%city%', '%state%', '%zip%') THEN TRUE
+            ELSE FALSE
+        END
+    )) INTO col_mappings
+    FROM IDENTIFIER(:columns_ref)
+    WHERE TABLE_SCHEMA = :source_schema
+    AND TABLE_NAME = :source_table;
+
+    result := OBJECT_CONSTRUCT(
+        'source', OBJECT_CONSTRUCT(
+            'database', :source_database,
+            'schema', :source_schema,
+            'table', :source_table
+        ),
+        'mapping_suggestions', col_mappings,
+        'sample_query', CONCAT(
+            'SELECT * FROM ', :source_database, '.', :source_schema, '.', :source_table, ' LIMIT 10'
+        )
+    );
+    
+    RETURN result;
+END;
+$$;

--- a/samples/meta-capi-pipeline/sql/00_discovery/pipeline_config.sql
+++ b/samples/meta-capi-pipeline/sql/00_discovery/pipeline_config.sql
@@ -1,0 +1,404 @@
+-- =============================================================================
+-- META CAPI PIPELINE CONFIG GENERATOR
+-- Generates reviewable config files for human verification before deployment
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- GENERATE PIPELINE CONFIG (Human Review)
+-- Creates a config object for review - does NOT create any objects
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE generate_pipeline_config(
+    source_database VARCHAR,
+    source_schema VARCHAR,
+    source_table VARCHAR,
+    event_type VARCHAR DEFAULT 'Purchase',
+    action_source VARCHAR DEFAULT 'website'
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    config VARIANT;
+    col_mappings VARIANT;
+BEGIN
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(
+        'source_column', COLUMN_NAME,
+        'source_type', DATA_TYPE,
+        'target_column', 
+        CASE 
+            WHEN LOWER(COLUMN_NAME) LIKE '%email%' OR LOWER(COLUMN_NAME) = 'em' THEN 'EM'
+            WHEN LOWER(COLUMN_NAME) LIKE '%phone%' OR LOWER(COLUMN_NAME) = 'ph' THEN 'PH'
+            WHEN LOWER(COLUMN_NAME) LIKE '%first%name%' OR LOWER(COLUMN_NAME) = 'fn' THEN 'FN'
+            WHEN LOWER(COLUMN_NAME) LIKE '%last%name%' OR LOWER(COLUMN_NAME) = 'ln' THEN 'LN'
+            WHEN LOWER(COLUMN_NAME) LIKE '%amount%' OR LOWER(COLUMN_NAME) LIKE '%value%' OR LOWER(COLUMN_NAME) LIKE '%total%' OR LOWER(COLUMN_NAME) LIKE '%revenue%' THEN 'VALUE'
+            WHEN LOWER(COLUMN_NAME) LIKE '%currency%' THEN 'CURRENCY'
+            WHEN LOWER(COLUMN_NAME) LIKE '%time%' OR LOWER(COLUMN_NAME) LIKE '%date%' OR LOWER(COLUMN_NAME) LIKE '%created%' THEN 'EVENT_TIME'
+            WHEN LOWER(COLUMN_NAME) LIKE '%order%id%' THEN 'ORDER_ID'
+            WHEN LOWER(COLUMN_NAME) LIKE '%user%id%' OR LOWER(COLUMN_NAME) LIKE '%customer%id%' THEN 'EXTERNAL_ID'
+            WHEN LOWER(COLUMN_NAME) LIKE '%ip%' THEN 'CLIENT_IP_ADDRESS'
+            WHEN LOWER(COLUMN_NAME) LIKE '%agent%' OR LOWER(COLUMN_NAME) LIKE '%browser%' THEN 'CLIENT_USER_AGENT'
+            WHEN LOWER(COLUMN_NAME) LIKE '%city%' THEN 'CT'
+            WHEN LOWER(COLUMN_NAME) LIKE '%state%' OR LOWER(COLUMN_NAME) LIKE '%province%' THEN 'ST'
+            WHEN LOWER(COLUMN_NAME) LIKE '%zip%' OR LOWER(COLUMN_NAME) LIKE '%postal%' THEN 'ZP'
+            WHEN LOWER(COLUMN_NAME) LIKE '%country%' THEN 'COUNTRY'
+            WHEN LOWER(COLUMN_NAME) LIKE '%gender%' THEN 'GE'
+            WHEN LOWER(COLUMN_NAME) LIKE '%birth%' OR LOWER(COLUMN_NAME) LIKE '%dob%' THEN 'DB'
+            ELSE NULL
+        END,
+        'requires_hashing', 
+        CASE 
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%phone%', '%first%', '%last%', '%city%', '%state%', '%zip%', '%gender%', '%birth%', '%country%') THEN TRUE
+            ELSE FALSE
+        END,
+        'include', 
+        CASE 
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%phone%', '%first%', '%last%', '%amount%', '%value%', '%total%', '%time%', '%date%', '%created%', '%order%', '%user%id%', '%customer%') THEN TRUE
+            ELSE FALSE
+        END,
+        'notes', ''
+    )) INTO col_mappings
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_CATALOG = :source_database
+    AND TABLE_SCHEMA = :source_schema
+    AND TABLE_NAME = :source_table;
+
+    config := OBJECT_CONSTRUCT(
+        '_metadata', OBJECT_CONSTRUCT(
+            'generated_at', CURRENT_TIMESTAMP(),
+            'generated_by', CURRENT_USER(),
+            'status', 'PENDING_REVIEW',
+            'instructions', 'Review mappings below. Edit as needed, then call deploy_pipeline_from_config() to activate.'
+        ),
+        'source', OBJECT_CONSTRUCT(
+            'database', :source_database,
+            'schema', :source_schema,
+            'table', :source_table,
+            'full_path', CONCAT(:source_database, '.', :source_schema, '.', :source_table)
+        ),
+        'target', OBJECT_CONSTRUCT(
+            'database', 'META_CAPI_DB',
+            'schema', 'PIPELINE', 
+            'table', 'META_CAPI_EVENTS'
+        ),
+        'event_settings', OBJECT_CONSTRUCT(
+            'event_type', :event_type,
+            'action_source', :action_source
+        ),
+        'column_mappings', col_mappings,
+        'pipeline_settings', OBJECT_CONSTRUCT(
+            'pipeline_name', UPPER(REPLACE(:source_table, ' ', '_')) || '_TO_META',
+            'schedule', 'ON_NEW_DATA',
+            'batch_size', 10000,
+            'enabled', FALSE
+        ),
+        'validation_rules', ARRAY_CONSTRUCT(
+            OBJECT_CONSTRUCT('rule', 'EVENT_TIME must not be NULL', 'severity', 'ERROR'),
+            OBJECT_CONSTRUCT('rule', 'At least one PII field (EM, PH, or EXTERNAL_ID) required', 'severity', 'ERROR'),
+            OBJECT_CONSTRUCT('rule', 'VALUE requires CURRENCY to be set', 'severity', 'WARNING')
+        )
+    );
+    
+    RETURN config;
+END;
+$$;
+
+-- =============================================================================
+-- SAVE CONFIG TO TABLE
+-- Persists config for later review and deployment
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS META_CAPI_DB.PIPELINE.PIPELINE_CONFIGS (
+    CONFIG_ID VARCHAR(100) DEFAULT UUID_STRING() PRIMARY KEY,
+    CONFIG_NAME VARCHAR(200),
+    SOURCE_TABLE VARCHAR(500),
+    CONFIG VARIANT,
+    STATUS VARCHAR(20) DEFAULT 'PENDING_REVIEW',
+    CREATED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    CREATED_BY VARCHAR(100) DEFAULT CURRENT_USER(),
+    REVIEWED_AT TIMESTAMP_NTZ,
+    REVIEWED_BY VARCHAR(100),
+    DEPLOYED_AT TIMESTAMP_NTZ,
+    NOTES VARCHAR(2000)
+);
+
+CREATE OR REPLACE PROCEDURE save_pipeline_config(
+    config VARIANT,
+    config_name VARCHAR DEFAULT NULL
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    config_id VARCHAR;
+    name VARCHAR;
+BEGIN
+    config_id := UUID_STRING();
+    name := COALESCE(:config_name, config:pipeline_settings:pipeline_name::VARCHAR);
+    
+    INSERT INTO META_CAPI_DB.PIPELINE.PIPELINE_CONFIGS (CONFIG_ID, CONFIG_NAME, SOURCE_TABLE, CONFIG, STATUS)
+    VALUES (
+        :config_id,
+        :name,
+        config:source:full_path::VARCHAR,
+        :config,
+        'PENDING_REVIEW'
+    );
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'SAVED',
+        'config_id', config_id,
+        'config_name', name,
+        'next_steps', ARRAY_CONSTRUCT(
+            '1. Review config: SELECT CONFIG FROM PIPELINE_CONFIGS WHERE CONFIG_ID = ''' || config_id || '''',
+            '2. Edit if needed: CALL update_pipeline_config(''' || config_id || ''', <updated_config>)',
+            '3. Approve: CALL approve_pipeline_config(''' || config_id || ''')',
+            '4. Deploy: CALL deploy_pipeline_from_config(''' || config_id || ''')'
+        )
+    );
+END;
+$$;
+
+-- =============================================================================
+-- UPDATE CONFIG
+-- Allows editing config before deployment
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE update_pipeline_config(
+    config_id VARCHAR,
+    updated_config VARIANT
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+BEGIN
+    UPDATE META_CAPI_DB.PIPELINE.PIPELINE_CONFIGS
+    SET CONFIG = :updated_config,
+        STATUS = 'PENDING_REVIEW'
+    WHERE CONFIG_ID = :config_id;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'UPDATED',
+        'config_id', config_id,
+        'message', 'Config updated. Review and approve before deploying.'
+    );
+END;
+$$;
+
+-- =============================================================================
+-- APPROVE CONFIG
+-- Marks config as reviewed and ready for deployment
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE approve_pipeline_config(
+    config_id VARCHAR,
+    reviewer_notes VARCHAR DEFAULT NULL
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+BEGIN
+    UPDATE META_CAPI_DB.PIPELINE.PIPELINE_CONFIGS
+    SET STATUS = 'APPROVED',
+        REVIEWED_AT = CURRENT_TIMESTAMP(),
+        REVIEWED_BY = CURRENT_USER(),
+        NOTES = :reviewer_notes
+    WHERE CONFIG_ID = :config_id;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'APPROVED',
+        'config_id', config_id,
+        'reviewed_by', CURRENT_USER(),
+        'message', 'Config approved. Ready for deployment.',
+        'deploy_command', 'CALL deploy_pipeline_from_config(''' || config_id || ''')'
+    );
+END;
+$$;
+
+-- =============================================================================
+-- DEPLOY FROM CONFIG
+-- Creates actual pipeline objects from approved config
+-- Builds USER_DATA and CUSTOM_DATA VARIANT columns from column_mappings
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE deploy_pipeline_from_config(config_id VARCHAR)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    config VARIANT;
+    status VARCHAR;
+    pipe_name VARCHAR;
+    stream_name VARCHAR;
+    task_name VARCHAR;
+    view_name VARCHAR;
+    source_path VARCHAR;
+    user_data_parts VARCHAR DEFAULT '';
+    custom_data_parts VARCHAR DEFAULT '';
+    event_id_expr VARCHAR;
+    event_time_expr VARCHAR;
+    event_source_url_expr VARCHAR;
+BEGIN
+    SELECT c.CONFIG, c.STATUS INTO config, status
+    FROM META_CAPI_DB.PIPELINE.PIPELINE_CONFIGS c
+    WHERE c.CONFIG_ID = :config_id;
+    
+    IF (status != 'APPROVED') THEN
+        RETURN OBJECT_CONSTRUCT(
+            'status', 'ERROR',
+            'message', 'Config must be APPROVED before deployment. Current status: ' || status,
+            'action', 'CALL approve_pipeline_config(''' || config_id || ''')'
+        );
+    END IF;
+    
+    pipe_name := config:pipeline_settings:pipeline_name::VARCHAR;
+    stream_name := pipe_name || '_STREAM';
+    task_name := pipe_name || '_TASK';
+    view_name := pipe_name || '_VW';
+    source_path := config:source:full_path::VARCHAR;
+    
+    -- Determine EVENT_ID, EVENT_TIME, EVENT_SOURCE_URL from mappings
+    event_id_expr := '''evt_'' || UUID_STRING()';
+    event_time_expr := 'CURRENT_TIMESTAMP()';
+    event_source_url_expr := 'NULL';
+    
+    -- Route column_mappings into USER_DATA or CUSTOM_DATA based on target_column
+    FOR mapping IN (SELECT VALUE FROM TABLE(FLATTEN(input => config:column_mappings)) WHERE VALUE:include::BOOLEAN = TRUE) DO
+        LET target VARCHAR := mapping:target_column::VARCHAR;
+        LET source VARCHAR := mapping:source_column::VARCHAR;
+        LET hashed BOOLEAN := mapping:requires_hashing::BOOLEAN;
+        LET col_expr VARCHAR;
+        
+        IF (target IS NULL) THEN
+            CONTINUE;
+        END IF;
+        
+        -- Top-level fields handled separately
+        IF (target = 'EVENT_ID') THEN
+            event_id_expr := 'COALESCE(' || source || '::VARCHAR, ''evt_'' || UUID_STRING())';
+            CONTINUE;
+        END IF;
+        IF (target = 'EVENT_TIME') THEN
+            event_time_expr := source || '::TIMESTAMP_NTZ';
+            CONTINUE;
+        END IF;
+        IF (target = 'EVENT_SOURCE_URL') THEN
+            event_source_url_expr := source;
+            CONTINUE;
+        END IF;
+        
+        -- Build expression (hashed or raw)
+        IF (hashed) THEN
+            col_expr := 'ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || source || ')), 256))';
+        ELSE
+            col_expr := source;
+        END IF;
+        
+        -- Route to USER_DATA or CUSTOM_DATA based on target field
+        IF (target IN ('EM', 'PH', 'FN', 'LN', 'GE', 'DB', 'CT', 'ST', 'ZP', 'COUNTRY', 'EXTERNAL_ID', 'CLIENT_IP_ADDRESS', 'CLIENT_USER_AGENT', 'FBC', 'FBP')) THEN
+            LET key_name VARCHAR := LOWER(target);
+            user_data_parts := user_data_parts || '''' || key_name || ''', ' || col_expr || ', ';
+        ELSE
+            LET key_name VARCHAR := LOWER(target);
+            custom_data_parts := custom_data_parts || '''' || key_name || ''', ' || col_expr || ', ';
+        END IF;
+    END FOR;
+    
+    -- Finalize VARIANT expressions
+    user_data_parts := RTRIM(user_data_parts, ', ');
+    custom_data_parts := RTRIM(custom_data_parts, ', ');
+    
+    LET user_data_sql VARCHAR := CASE WHEN user_data_parts = '' THEN 'NULL' ELSE 'OBJECT_CONSTRUCT_KEEP_NULL(' || user_data_parts || ')' END;
+    LET custom_data_sql VARCHAR := CASE WHEN custom_data_parts = '' THEN 'NULL' ELSE 'OBJECT_CONSTRUCT_KEEP_NULL(' || custom_data_parts || ')' END;
+    
+    -- Create stream
+    EXECUTE IMMEDIATE 'CREATE OR REPLACE STREAM META_CAPI_DB.PIPELINE.' || stream_name || 
+        ' ON TABLE ' || source_path || ' APPEND_ONLY = TRUE';
+    
+    -- Create mapping view with USER_DATA and CUSTOM_DATA VARIANT columns
+    EXECUTE IMMEDIATE '
+    CREATE OR REPLACE VIEW META_CAPI_DB.PIPELINE.' || view_name || ' AS
+    SELECT 
+        ' || event_id_expr || ' AS EVENT_ID,
+        ''' || config:event_settings:event_type::VARCHAR || ''' AS EVENT_NAME,
+        ' || event_time_expr || ' AS EVENT_TIME,
+        ''' || config:event_settings:action_source::VARCHAR || ''' AS ACTION_SOURCE,
+        ' || event_source_url_expr || ' AS EVENT_SOURCE_URL,
+        ' || user_data_sql || ' AS USER_DATA,
+        ' || custom_data_sql || ' AS CUSTOM_DATA
+    FROM META_CAPI_DB.PIPELINE.' || stream_name;
+    
+    -- Create task
+    EXECUTE IMMEDIATE '
+    CREATE OR REPLACE TASK META_CAPI_DB.PIPELINE.' || task_name || '
+        WAREHOUSE = COMPUTE_WH
+        SCHEDULE = ''60 MINUTE''
+        WHEN SYSTEM$STREAM_HAS_DATA(''META_CAPI_DB.PIPELINE.' || stream_name || ''')
+    AS
+        INSERT INTO META_CAPI_DB.PIPELINE.META_CAPI_EVENTS 
+        (EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, EVENT_SOURCE_URL, USER_DATA, CUSTOM_DATA, STATUS, CREATED_AT)
+        SELECT EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, EVENT_SOURCE_URL, USER_DATA, CUSTOM_DATA, ''PENDING'', CURRENT_TIMESTAMP()
+        FROM META_CAPI_DB.PIPELINE.' || view_name;
+    
+    -- Resume task
+    EXECUTE IMMEDIATE 'ALTER TASK META_CAPI_DB.PIPELINE.' || task_name || ' RESUME';
+    
+    -- Update config status
+    UPDATE META_CAPI_DB.PIPELINE.PIPELINE_CONFIGS
+    SET STATUS = 'DEPLOYED',
+        DEPLOYED_AT = CURRENT_TIMESTAMP()
+    WHERE CONFIG_ID = :config_id;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'DEPLOYED',
+        'config_id', config_id,
+        'pipeline_name', pipe_name,
+        'objects_created', OBJECT_CONSTRUCT(
+            'stream', stream_name,
+            'view', view_name,
+            'task', task_name
+        ),
+        'message', 'Pipeline deployed and active.'
+    );
+END;
+$$;
+
+-- =============================================================================
+-- LIST CONFIGS
+-- Shows all pipeline configs and their status
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE list_pipeline_configs()
+RETURNS TABLE (
+    config_id VARCHAR,
+    config_name VARCHAR,
+    source_table VARCHAR,
+    status VARCHAR,
+    created_at TIMESTAMP_NTZ,
+    created_by VARCHAR,
+    reviewed_by VARCHAR,
+    deployed_at TIMESTAMP_NTZ
+)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+BEGIN
+    res := (
+        SELECT 
+            CONFIG_ID,
+            CONFIG_NAME,
+            SOURCE_TABLE,
+            STATUS,
+            CREATED_AT,
+            CREATED_BY,
+            REVIEWED_BY,
+            DEPLOYED_AT
+        FROM META_CAPI_DB.PIPELINE.PIPELINE_CONFIGS
+        ORDER BY CREATED_AT DESC
+    );
+    RETURN TABLE(res);
+END;
+$$;

--- a/samples/meta-capi-pipeline/sql/00_discovery/pipeline_generator.sql
+++ b/samples/meta-capi-pipeline/sql/00_discovery/pipeline_generator.sql
@@ -1,0 +1,267 @@
+-- =============================================================================
+-- META CAPI PIPELINE GENERATOR
+-- Creates automated pipelines from source tables to META_CAPI_EVENTS
+-- Uses VARIANT columns (USER_DATA, CUSTOM_DATA) for flexible field support
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- GENERATE LOADING PIPELINE
+-- Creates a stream + mapping view + task for continuous data loading
+--
+-- column_mapping keys:
+--   Standard: event_id, event_time, event_source_url
+--   user_data: email, phone, first_name, last_name, gender, date_of_birth,
+--              city, state, zip, country, external_id, ip_address, user_agent,
+--              fbc, fbp, + any custom user_data keys
+--   custom_data: value, currency, content_ids, content_type, contents,
+--                num_items, search_string, order_id, predicted_ltv, + any custom keys
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE generate_loading_pipeline(
+    source_database VARCHAR,
+    source_schema VARCHAR,
+    source_table VARCHAR,
+    column_mapping VARIANT,
+    event_type VARCHAR DEFAULT 'Purchase',
+    action_source VARCHAR DEFAULT 'website',
+    pipeline_name VARCHAR DEFAULT NULL
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    pipe_name VARCHAR;
+    stream_name VARCHAR;
+    task_name VARCHAR;
+    view_name VARCHAR;
+    user_data_sql VARCHAR;
+    custom_data_sql VARCHAR;
+BEGIN
+    pipe_name := COALESCE(:pipeline_name, REPLACE(:source_table, ' ', '_') || '_PIPELINE');
+    stream_name := pipe_name || '_STREAM';
+    task_name := pipe_name || '_TASK';
+    view_name := pipe_name || '_VW';
+    
+    -- Build USER_DATA OBJECT_CONSTRUCT from column_mapping
+    user_data_sql := 'OBJECT_CONSTRUCT_KEEP_NULL(';
+    
+    -- PII fields (hashed)
+    IF (column_mapping:email IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''em'', ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || column_mapping:email::VARCHAR || ')), 256)), ';
+    END IF;
+    IF (column_mapping:phone IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''ph'', ARRAY_CONSTRUCT(SHA2(REGEXP_REPLACE(' || column_mapping:phone::VARCHAR || ', ''[^0-9]'', ''''), 256)), ';
+    END IF;
+    IF (column_mapping:first_name IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''fn'', ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || column_mapping:first_name::VARCHAR || ')), 256)), ';
+    END IF;
+    IF (column_mapping:last_name IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''ln'', ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || column_mapping:last_name::VARCHAR || ')), 256)), ';
+    END IF;
+    IF (column_mapping:gender IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''ge'', ARRAY_CONSTRUCT(SHA2(LOWER(' || column_mapping:gender::VARCHAR || '), 256)), ';
+    END IF;
+    IF (column_mapping:date_of_birth IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''db'', ARRAY_CONSTRUCT(SHA2(' || column_mapping:date_of_birth::VARCHAR || '::VARCHAR, 256)), ';
+    END IF;
+    IF (column_mapping:city IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''ct'', ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || column_mapping:city::VARCHAR || ')), 256)), ';
+    END IF;
+    IF (column_mapping:state IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''st'', ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || column_mapping:state::VARCHAR || ')), 256)), ';
+    END IF;
+    IF (column_mapping:zip IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''zp'', ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || column_mapping:zip::VARCHAR || ')), 256)), ';
+    END IF;
+    IF (column_mapping:country IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''country'', ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || column_mapping:country::VARCHAR || ')), 256)), ';
+    END IF;
+    IF (column_mapping:external_id IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''external_id'', ARRAY_CONSTRUCT(' || column_mapping:external_id::VARCHAR || '::VARCHAR), ';
+    END IF;
+    
+    -- Non-PII fields (not hashed)
+    IF (column_mapping:ip_address IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''client_ip_address'', ' || column_mapping:ip_address::VARCHAR || ', ';
+    END IF;
+    IF (column_mapping:user_agent IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''client_user_agent'', ' || column_mapping:user_agent::VARCHAR || ', ';
+    END IF;
+    IF (column_mapping:fbc IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''fbc'', ' || column_mapping:fbc::VARCHAR || ', ';
+    END IF;
+    IF (column_mapping:fbp IS NOT NULL) THEN
+        user_data_sql := user_data_sql || '''fbp'', ' || column_mapping:fbp::VARCHAR || ', ';
+    END IF;
+    
+    -- Any additional user_data fields from custom_user_data mapping
+    IF (column_mapping:custom_user_data IS NOT NULL) THEN
+        FOR rec IN (SELECT key, value FROM TABLE(FLATTEN(input => :column_mapping:custom_user_data))) DO
+            user_data_sql := user_data_sql || '''' || rec.key || ''', ' || rec.value::VARCHAR || ', ';
+        END FOR;
+    END IF;
+    
+    -- Remove trailing comma and close
+    user_data_sql := RTRIM(user_data_sql, ', ') || ')';
+    IF (user_data_sql = 'OBJECT_CONSTRUCT_KEEP_NULL()') THEN
+        user_data_sql := 'NULL';
+    END IF;
+    
+    -- Build CUSTOM_DATA OBJECT_CONSTRUCT from column_mapping
+    custom_data_sql := 'OBJECT_CONSTRUCT_KEEP_NULL(';
+    
+    IF (column_mapping:value IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''value'', ' || column_mapping:value::VARCHAR || '::FLOAT, ';
+    END IF;
+    IF (column_mapping:currency IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''currency'', ' || column_mapping:currency::VARCHAR || ', ';
+    ELSIF (column_mapping:value IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''currency'', ''USD'', ';
+    END IF;
+    IF (column_mapping:content_ids IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''content_ids'', ARRAY_CONSTRUCT(' || column_mapping:content_ids::VARCHAR || '::VARCHAR), ';
+    END IF;
+    IF (column_mapping:content_type IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''content_type'', ' || column_mapping:content_type::VARCHAR || ', ';
+    END IF;
+    IF (column_mapping:contents IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''contents'', ' || column_mapping:contents::VARCHAR || ', ';
+    END IF;
+    IF (column_mapping:num_items IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''num_items'', ' || column_mapping:num_items::VARCHAR || ', ';
+    END IF;
+    IF (column_mapping:search_string IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''search_string'', ' || column_mapping:search_string::VARCHAR || ', ';
+    END IF;
+    IF (column_mapping:order_id IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''order_id'', ' || column_mapping:order_id::VARCHAR || '::VARCHAR, ';
+    END IF;
+    IF (column_mapping:predicted_ltv IS NOT NULL) THEN
+        custom_data_sql := custom_data_sql || '''predicted_ltv'', ' || column_mapping:predicted_ltv::VARCHAR || '::FLOAT, ';
+    END IF;
+    
+    -- Any additional custom_data fields from custom_fields mapping
+    IF (column_mapping:custom_fields IS NOT NULL) THEN
+        FOR rec IN (SELECT key, value FROM TABLE(FLATTEN(input => :column_mapping:custom_fields))) DO
+            custom_data_sql := custom_data_sql || '''' || rec.key || ''', ' || rec.value::VARCHAR || ', ';
+        END FOR;
+    END IF;
+    
+    -- Remove trailing comma and close
+    custom_data_sql := RTRIM(custom_data_sql, ', ') || ')';
+    IF (custom_data_sql = 'OBJECT_CONSTRUCT_KEEP_NULL()') THEN
+        custom_data_sql := 'NULL';
+    END IF;
+    
+    -- Create stream on source table
+    EXECUTE IMMEDIATE 'CREATE OR REPLACE STREAM META_CAPI_DB.PIPELINE.' || stream_name || 
+        ' ON TABLE ' || source_database || '.' || source_schema || '.' || source_table ||
+        ' APPEND_ONLY = TRUE';
+    
+    -- Create mapping view
+    EXECUTE IMMEDIATE '
+    CREATE OR REPLACE VIEW META_CAPI_DB.PIPELINE.' || view_name || ' AS
+    SELECT 
+        ' || CASE WHEN column_mapping:event_id IS NOT NULL 
+            THEN 'COALESCE(' || column_mapping:event_id::VARCHAR || '::VARCHAR, ''evt_'' || UUID_STRING())'
+            ELSE '''evt_'' || UUID_STRING()' END || ' AS EVENT_ID,
+        ''' || event_type || ''' AS EVENT_NAME,
+        ' || COALESCE(column_mapping:event_time::VARCHAR, 'CURRENT_TIMESTAMP()') || '::TIMESTAMP_NTZ AS EVENT_TIME,
+        ''' || action_source || ''' AS ACTION_SOURCE,
+        ' || COALESCE(column_mapping:event_source_url::VARCHAR, 'NULL') || ' AS EVENT_SOURCE_URL,
+        ' || user_data_sql || ' AS USER_DATA,
+        ' || custom_data_sql || ' AS CUSTOM_DATA
+    FROM META_CAPI_DB.PIPELINE.' || stream_name;
+    
+    -- Create task to load from view into META_CAPI_EVENTS
+    EXECUTE IMMEDIATE '
+    CREATE OR REPLACE TASK META_CAPI_DB.PIPELINE.' || task_name || '
+        WAREHOUSE = COMPUTE_WH
+        SCHEDULE = ''60 MINUTE''
+        WHEN SYSTEM$STREAM_HAS_DATA(''META_CAPI_DB.PIPELINE.' || stream_name || ''')
+    AS
+        INSERT INTO META_CAPI_DB.PIPELINE.META_CAPI_EVENTS 
+        (EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, EVENT_SOURCE_URL, USER_DATA, CUSTOM_DATA, STATUS, CREATED_AT)
+        SELECT EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, EVENT_SOURCE_URL, USER_DATA, CUSTOM_DATA, ''PENDING'', CURRENT_TIMESTAMP()
+        FROM META_CAPI_DB.PIPELINE.' || view_name;
+    
+    -- Resume task
+    EXECUTE IMMEDIATE 'ALTER TASK META_CAPI_DB.PIPELINE.' || task_name || ' RESUME';
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'SUCCESS',
+        'pipeline_name', pipe_name,
+        'objects_created', OBJECT_CONSTRUCT(
+            'stream', stream_name,
+            'view', view_name,
+            'task', task_name
+        ),
+        'source', CONCAT(source_database, '.', source_schema, '.', source_table),
+        'message', 'Pipeline created and active. New rows in source table will automatically flow to META_CAPI_EVENTS.'
+    );
+END;
+$$;
+
+-- =============================================================================
+-- LIST ACTIVE PIPELINES
+-- Shows all discovery pipelines and their status
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE list_capi_pipelines()
+RETURNS TABLE (
+    pipeline_name VARCHAR,
+    stream_name VARCHAR,
+    task_name VARCHAR,
+    task_state VARCHAR,
+    last_run TIMESTAMP_NTZ,
+    rows_loaded INT
+)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+BEGIN
+    res := (
+        SELECT 
+            REPLACE(t.NAME, '_TASK', '') AS pipeline_name,
+            REPLACE(t.NAME, '_TASK', '_STREAM') AS stream_name,
+            t.NAME AS task_name,
+            t.STATE AS task_state,
+            t.LAST_COMMITTED_ON AS last_run,
+            0 AS rows_loaded
+        FROM TABLE(INFORMATION_SCHEMA.TASK_HISTORY(
+            SCHEDULED_TIME_RANGE_START => DATEADD('day', -7, CURRENT_TIMESTAMP()),
+            RESULT_LIMIT => 100
+        )) t
+        WHERE t.DATABASE_NAME = 'META_CAPI_DB'
+        AND t.SCHEMA_NAME = 'PIPELINE'
+        AND t.NAME LIKE '%_PIPELINE_TASK'
+        QUALIFY ROW_NUMBER() OVER (PARTITION BY t.NAME ORDER BY t.SCHEDULED_TIME DESC) = 1
+    );
+    RETURN TABLE(res);
+END;
+$$;
+
+-- =============================================================================
+-- DROP PIPELINE
+-- Removes all objects associated with a pipeline
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE drop_capi_pipeline(pipeline_name VARCHAR)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+BEGIN
+    EXECUTE IMMEDIATE 'ALTER TASK META_CAPI_DB.PIPELINE.' || pipeline_name || '_TASK SUSPEND';
+    EXECUTE IMMEDIATE 'DROP TASK IF EXISTS META_CAPI_DB.PIPELINE.' || pipeline_name || '_TASK';
+    EXECUTE IMMEDIATE 'DROP VIEW IF EXISTS META_CAPI_DB.PIPELINE.' || pipeline_name || '_VW';
+    EXECUTE IMMEDIATE 'DROP STREAM IF EXISTS META_CAPI_DB.PIPELINE.' || pipeline_name || '_STREAM';
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'SUCCESS',
+        'message', 'Pipeline ' || pipeline_name || ' and all associated objects dropped.'
+    );
+END;
+$$;

--- a/samples/meta-capi-pipeline/sql/01_setup/network_access.sql
+++ b/samples/meta-capi-pipeline/sql/01_setup/network_access.sql
@@ -1,0 +1,45 @@
+-- =============================================================================
+-- META CAPI EXTERNAL NETWORK ACCESS SETUP
+-- Configures secure access to graph.facebook.com
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- NETWORK RULE - Allow egress to Meta's Graph API and Use Case Recommendation API
+-- =============================================================================
+CREATE OR REPLACE NETWORK RULE meta_capi_network_rule
+    MODE = EGRESS
+    TYPE = HOST_PORT
+    VALUE_LIST = ('graph.facebook.com:443', 'api.facebook.com:443');
+
+-- =============================================================================
+-- SECRET - Store Meta Access Token securely
+-- Replace <ACCESS_TOKEN> with actual token
+-- =============================================================================
+CREATE OR REPLACE SECRET meta_capi_access_token
+    TYPE = GENERIC_STRING
+    SECRET_STRING = '<ACCESS_TOKEN>';
+
+-- =============================================================================
+-- EXTERNAL ACCESS INTEGRATION - Combine rule and secret
+-- =============================================================================
+CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION meta_capi_integration
+    ALLOWED_NETWORK_RULES = (meta_capi_network_rule)
+    ALLOWED_AUTHENTICATION_SECRETS = (meta_capi_access_token)
+    ENABLED = TRUE;
+
+-- =============================================================================
+-- GRANT USAGE - Allow functions to use the integration
+-- =============================================================================
+GRANT USAGE ON INTEGRATION meta_capi_integration TO ROLE <ROLE_NAME>;
+
+-- =============================================================================
+-- STORE PIXEL ID IN CONFIG
+-- Replace <PIXEL_ID> with actual pixel ID
+-- =============================================================================
+MERGE INTO META_CAPI_CONFIG t
+USING (SELECT 'PIXEL_ID' AS CONFIG_KEY, '<PIXEL_ID>' AS CONFIG_VALUE) s
+ON t.CONFIG_KEY = s.CONFIG_KEY
+WHEN MATCHED THEN UPDATE SET CONFIG_VALUE = s.CONFIG_VALUE, UPDATED_AT = CURRENT_TIMESTAMP()
+WHEN NOT MATCHED THEN INSERT (CONFIG_KEY, CONFIG_VALUE) VALUES (s.CONFIG_KEY, s.CONFIG_VALUE);

--- a/samples/meta-capi-pipeline/sql/01_setup/schema.sql
+++ b/samples/meta-capi-pipeline/sql/01_setup/schema.sql
@@ -1,0 +1,124 @@
+-- =============================================================================
+-- META CAPI SCHEMA SETUP
+-- Creates database, schema, and tables for Meta Conversions API pipeline
+-- =============================================================================
+
+-- Create database and schema
+CREATE DATABASE IF NOT EXISTS META_CAPI_DB;
+CREATE SCHEMA IF NOT EXISTS META_CAPI_DB.PIPELINE;
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- EVENTS TABLE - Flexible schema supporting all Meta standard + custom events
+-- Uses VARIANT columns for user_data and custom_data to support arbitrary fields
+-- without schema changes when Meta adds new parameters.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS META_CAPI_EVENTS (
+    -- Primary Key (client-provided for deduplication, or auto-generated)
+    EVENT_ID VARCHAR(100) NOT NULL,
+
+    -- Server Event Parameters (Required)
+    EVENT_NAME VARCHAR(50) NOT NULL,
+    EVENT_TIME TIMESTAMP_NTZ NOT NULL,
+    ACTION_SOURCE VARCHAR(20) NOT NULL,
+    EVENT_SOURCE_URL VARCHAR(2000),
+
+    -- User Data (pre-hashed PII + browser/device identifiers)
+    -- Keys: em, ph, fn, ln, ge, db, ct, st, zp, country, external_id,
+    --        client_ip_address, client_user_agent, fbc, fbp, + any future fields
+    USER_DATA VARIANT,
+
+    -- Custom Data (event-specific parameters)
+    -- Keys: value, currency, content_ids, content_type, contents, num_items,
+    --        search_string, order_id, predicted_ltv, delivery_category, + any future fields
+    CUSTOM_DATA VARIANT,
+
+    -- Processing Metadata
+    CREATED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    PROCESSED_AT TIMESTAMP_NTZ,
+    STATUS VARCHAR(20) DEFAULT 'PENDING',
+    META_RESPONSE VARIANT,
+    ERROR_MESSAGE VARCHAR(2000),
+    RETRY_COUNT INTEGER DEFAULT 0,
+
+    PRIMARY KEY (EVENT_ID)
+);
+
+-- =============================================================================
+-- LOG TABLE - Track all API calls and responses
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS META_CAPI_LOG (
+    LOG_ID NUMBER AUTOINCREMENT,
+    BATCH_ID VARCHAR(100),
+    EVENT_ID VARCHAR(100),
+    STATUS VARCHAR(20),
+    RESPONSE VARIANT,
+    PROCESSED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (LOG_ID)
+);
+
+-- =============================================================================
+-- CONFIG TABLE - Store pipeline configuration
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS META_CAPI_CONFIG (
+    CONFIG_KEY VARCHAR(100) PRIMARY KEY,
+    CONFIG_VALUE VARCHAR(2000),
+    UPDATED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+);
+
+-- =============================================================================
+-- VALIDATION VIEW - Quick data quality check
+-- =============================================================================
+CREATE OR REPLACE VIEW V_CAPI_VALIDATION AS
+SELECT 
+    EVENT_ID,
+    EVENT_NAME,
+    CASE 
+        WHEN EVENT_NAME IS NULL THEN 'Missing event_name'
+        WHEN EVENT_TIME IS NULL THEN 'Missing event_time'
+        WHEN ACTION_SOURCE IS NULL THEN 'Missing action_source'
+        WHEN ACTION_SOURCE = 'website' AND EVENT_SOURCE_URL IS NULL THEN 'Website events require event_source_url'
+        WHEN ACTION_SOURCE = 'website' AND USER_DATA:client_user_agent IS NULL THEN 'Website events require client_user_agent'
+        WHEN EVENT_NAME IN ('Purchase', 'Donate', 'StartTrial', 'Subscribe') AND CUSTOM_DATA:value IS NULL THEN 'Value required for this event type'
+        WHEN CUSTOM_DATA:value IS NOT NULL AND CUSTOM_DATA:currency IS NULL THEN 'Currency required when value is set'
+        WHEN USER_DATA IS NULL OR (USER_DATA:em IS NULL AND USER_DATA:ph IS NULL AND USER_DATA:external_id IS NULL) THEN 'At least one user identifier required (em, ph, or external_id)'
+        ELSE 'VALID'
+    END AS VALIDATION_STATUS
+FROM META_CAPI_EVENTS
+WHERE STATUS = 'PENDING';
+
+-- =============================================================================
+-- INDEXES
+-- =============================================================================
+CREATE INDEX IF NOT EXISTS IDX_EVENTS_STATUS ON META_CAPI_EVENTS(STATUS);
+CREATE INDEX IF NOT EXISTS IDX_EVENTS_CREATED ON META_CAPI_EVENTS(CREATED_AT);
+CREATE INDEX IF NOT EXISTS IDX_EVENTS_NAME ON META_CAPI_EVENTS(EVENT_NAME);
+CREATE INDEX IF NOT EXISTS IDX_LOG_BATCH ON META_CAPI_LOG(BATCH_ID);
+
+-- =============================================================================
+-- MIGRATION HELPER - Convert existing data from old schema to new
+-- Run this ONCE if upgrading from the fixed-column schema
+-- =============================================================================
+-- CREATE TABLE META_CAPI_EVENTS_V2 AS
+-- SELECT
+--     EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, EVENT_SOURCE_URL,
+--     OBJECT_CONSTRUCT_KEEP_NULL(
+--         'em', EM, 'ph', PH, 'fn', FN, 'ln', LN,
+--         'ge', GE, 'db', DB, 'ct', CT, 'st', ST, 'zp', ZP,
+--         'country', COUNTRY, 'external_id', EXTERNAL_ID,
+--         'client_ip_address', CLIENT_IP_ADDRESS,
+--         'client_user_agent', CLIENT_USER_AGENT,
+--         'fbc', FBC, 'fbp', FBP
+--     ) AS USER_DATA,
+--     OBJECT_CONSTRUCT_KEEP_NULL(
+--         'value', VALUE, 'currency', CURRENCY,
+--         'content_ids', CONTENT_IDS, 'content_type', CONTENT_TYPE,
+--         'contents', CONTENTS, 'num_items', NUM_ITEMS,
+--         'search_string', SEARCH_STRING, 'order_id', ORDER_ID,
+--         'predicted_ltv', PREDICTED_LTV
+--     ) AS CUSTOM_DATA,
+--     CREATED_AT, PROCESSED_AT, STATUS, META_RESPONSE, ERROR_MESSAGE, RETRY_COUNT
+-- FROM META_CAPI_EVENTS;
+-- ALTER TABLE META_CAPI_EVENTS RENAME TO META_CAPI_EVENTS_OLD;
+-- ALTER TABLE META_CAPI_EVENTS_V2 RENAME TO META_CAPI_EVENTS;

--- a/samples/meta-capi-pipeline/sql/02_processing/procedures.sql
+++ b/samples/meta-capi-pipeline/sql/02_processing/procedures.sql
@@ -1,0 +1,152 @@
+-- =============================================================================
+-- META CAPI PROCESSING PROCEDURES
+-- Batch processing and event management
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- MAIN PROCESSING PROCEDURE
+-- Processes pending events and sends to Meta CAPI
+-- USER_DATA and CUSTOM_DATA are passed through directly as pre-built VARIANT
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE process_pending_capi_events(
+    pixel_id VARCHAR,
+    test_event_code VARCHAR DEFAULT NULL
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    batch_id VARCHAR;
+    processed_count INTEGER DEFAULT 0;
+    sent_count INTEGER DEFAULT 0;
+    failed_count INTEGER DEFAULT 0;
+BEGIN
+    batch_id := UUID_STRING();
+    
+    INSERT INTO META_CAPI_LOG (BATCH_ID, EVENT_ID, STATUS, RESPONSE, PROCESSED_AT)
+    SELECT 
+        :batch_id,
+        r.EVENT_ID,
+        r.STATUS,
+        r.RESPONSE,
+        CURRENT_TIMESTAMP()
+    FROM (
+        SELECT ARRAY_AGG(
+            OBJECT_CONSTRUCT(
+                'event_name', EVENT_NAME,
+                'event_time', DATE_PART('epoch_second', EVENT_TIME)::INTEGER,
+                'event_id', EVENT_ID,
+                'action_source', ACTION_SOURCE,
+                'event_source_url', EVENT_SOURCE_URL,
+                'user_data', USER_DATA,
+                'custom_data', CUSTOM_DATA
+            )
+        ) AS events_array
+        FROM META_CAPI_EVENTS
+        WHERE STATUS = 'PENDING'
+    ) batch,
+    TABLE(send_to_meta_capi(:pixel_id, batch.events_array, :test_event_code)) r;
+    
+    UPDATE META_CAPI_EVENTS e
+    SET 
+        STATUS = l.STATUS,
+        PROCESSED_AT = l.PROCESSED_AT,
+        META_RESPONSE = l.RESPONSE,
+        ERROR_MESSAGE = CASE 
+            WHEN l.STATUS = 'FAILED' THEN l.RESPONSE:error::VARCHAR 
+            ELSE NULL 
+        END
+    FROM META_CAPI_LOG l
+    WHERE e.EVENT_ID = l.EVENT_ID
+    AND l.BATCH_ID = :batch_id;
+    
+    SELECT COUNT(*) INTO processed_count FROM META_CAPI_LOG WHERE BATCH_ID = :batch_id;
+    SELECT COUNT(*) INTO sent_count FROM META_CAPI_LOG WHERE BATCH_ID = :batch_id AND STATUS = 'SENT';
+    SELECT COUNT(*) INTO failed_count FROM META_CAPI_LOG WHERE BATCH_ID = :batch_id AND STATUS = 'FAILED';
+    
+    RETURN OBJECT_CONSTRUCT(
+        'batch_id', batch_id,
+        'processed', processed_count,
+        'sent', sent_count,
+        'failed', failed_count,
+        'timestamp', CURRENT_TIMESTAMP()
+    );
+END;
+$$;
+
+-- =============================================================================
+-- RESEND FAILED EVENTS
+-- Resets failed events for reprocessing
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE resend_failed_events(
+    max_retry INTEGER DEFAULT 3,
+    limit_count INTEGER DEFAULT 1000
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    reset_count INTEGER;
+BEGIN
+    CREATE OR REPLACE TEMPORARY TABLE _failed_to_retry AS
+    SELECT EVENT_ID FROM META_CAPI_DB.PIPELINE.META_CAPI_EVENTS
+    WHERE STATUS = 'FAILED' AND RETRY_COUNT < :max_retry
+    LIMIT :limit_count;
+    
+    UPDATE META_CAPI_DB.PIPELINE.META_CAPI_EVENTS 
+    SET 
+        STATUS = 'PENDING', 
+        RETRY_COUNT = RETRY_COUNT + 1,
+        ERROR_MESSAGE = NULL,
+        META_RESPONSE = NULL
+    WHERE EVENT_ID IN (SELECT EVENT_ID FROM _failed_to_retry);
+    
+    SELECT COUNT(*) INTO reset_count FROM _failed_to_retry;
+    
+    DROP TABLE IF EXISTS _failed_to_retry;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'events_reset', reset_count,
+        'max_retry', max_retry,
+        'timestamp', CURRENT_TIMESTAMP()
+    );
+END;
+$$;
+
+-- =============================================================================
+-- VALIDATE EVENTS
+-- Returns events with validation issues
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE validate_capi_events()
+RETURNS TABLE (event_id VARCHAR, event_name VARCHAR, issue VARCHAR)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+BEGIN
+    res := (
+        SELECT 
+            EVENT_ID,
+            EVENT_NAME,
+            CASE 
+                WHEN EVENT_NAME IS NULL THEN 'Missing event_name'
+                WHEN EVENT_TIME IS NULL THEN 'Missing event_time'
+                WHEN ACTION_SOURCE IS NULL THEN 'Missing action_source'
+                WHEN ACTION_SOURCE = 'website' AND EVENT_SOURCE_URL IS NULL THEN 'Website events require event_source_url'
+                WHEN ACTION_SOURCE = 'website' AND USER_DATA:client_user_agent IS NULL THEN 'Website events require client_user_agent'
+                WHEN EVENT_NAME IN ('Purchase', 'Donate', 'StartTrial', 'Subscribe') AND CUSTOM_DATA:value IS NULL THEN 'Value required for this event type'
+                WHEN CUSTOM_DATA:value IS NOT NULL AND CUSTOM_DATA:currency IS NULL THEN 'Currency required when value is set'
+                WHEN USER_DATA IS NULL OR (USER_DATA:em IS NULL AND USER_DATA:ph IS NULL AND USER_DATA:external_id IS NULL) THEN 'At least one user identifier required'
+            END AS ISSUE
+        FROM META_CAPI_EVENTS
+        WHERE STATUS = 'PENDING'
+        HAVING ISSUE IS NOT NULL
+    );
+    RETURN TABLE(res);
+END;
+$$;

--- a/samples/meta-capi-pipeline/sql/02_processing/task.sql
+++ b/samples/meta-capi-pipeline/sql/02_processing/task.sql
@@ -1,0 +1,57 @@
+-- =============================================================================
+-- META CAPI SCHEDULED TASK
+-- Automatic processing of pending events
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- CREATE TASK - Hourly processing
+-- Replace <WAREHOUSE> and <PIXEL_ID> with actual values
+-- =============================================================================
+CREATE OR REPLACE TASK meta_capi_send_events
+    WAREHOUSE = <WAREHOUSE>
+    SCHEDULE = 'USING CRON 0 * * * * UTC'  -- Every hour at minute 0
+    COMMENT = 'Processes pending Meta CAPI events hourly'
+AS
+    CALL process_pending_capi_events(
+        (SELECT CONFIG_VALUE FROM META_CAPI_CONFIG WHERE CONFIG_KEY = 'PIXEL_ID')
+    );
+
+-- =============================================================================
+-- ALTERNATIVE SCHEDULES
+-- =============================================================================
+
+-- Every 15 minutes
+-- SCHEDULE = 'USING CRON */15 * * * * UTC'
+
+-- Every 5 minutes
+-- SCHEDULE = 'USING CRON */5 * * * * UTC'
+
+-- Daily at midnight UTC
+-- SCHEDULE = 'USING CRON 0 0 * * * UTC'
+
+-- Every 30 minutes during business hours (9 AM - 6 PM UTC)
+-- SCHEDULE = 'USING CRON */30 9-18 * * * UTC'
+
+-- =============================================================================
+-- TASK MANAGEMENT
+-- =============================================================================
+
+-- Start the task
+ALTER TASK meta_capi_send_events RESUME;
+
+-- Stop the task
+-- ALTER TASK meta_capi_send_events SUSPEND;
+
+-- Check task status
+-- SHOW TASKS LIKE 'meta_capi_send_events';
+
+-- View task history
+-- SELECT * FROM TABLE(INFORMATION_SCHEMA.TASK_HISTORY(
+--     TASK_NAME => 'META_CAPI_SEND_EVENTS',
+--     SCHEDULED_TIME_RANGE_START => DATEADD('day', -1, CURRENT_TIMESTAMP())
+-- )) ORDER BY SCHEDULED_TIME DESC;
+
+-- Manual execution
+-- EXECUTE TASK meta_capi_send_events;

--- a/samples/meta-capi-pipeline/sql/02_processing/udtf.py
+++ b/samples/meta-capi-pipeline/sql/02_processing/udtf.py
@@ -1,0 +1,89 @@
+"""
+Meta CAPI Python UDTF
+Sends events to Meta's Conversions API via graph.facebook.com
+
+The UDTF is a pass-through: it receives pre-built event payloads (constructed
+by the calling procedure from USER_DATA and CUSTOM_DATA VARIANT columns) and
+posts them directly to Meta. It does NOT build or transform the payload.
+"""
+
+# =============================================================================
+# UDTF DEFINITION (Run this SQL to create the function)
+# =============================================================================
+UDTF_SQL = """
+CREATE OR REPLACE FUNCTION META_CAPI_DB.PIPELINE.send_to_meta_capi(
+    pixel_id VARCHAR,
+    events ARRAY,
+    test_event_code VARCHAR DEFAULT NULL
+)
+RETURNS TABLE (
+    event_id VARCHAR,
+    status VARCHAR,
+    response VARIANT,
+    events_received INT,
+    fbtrace_id VARCHAR
+)
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.11'
+PACKAGES = ('requests', 'snowflake-snowpark-python')
+HANDLER = 'MetaCAPIHandler'
+EXTERNAL_ACCESS_INTEGRATIONS = (meta_capi_integration)
+SECRETS = ('access_token' = meta_capi_access_token)
+AS $$
+import _snowflake
+import requests
+import json
+
+class MetaCAPIHandler:
+    def __init__(self):
+        self.access_token = _snowflake.get_generic_secret_string('access_token')
+        self.api_version = 'v22.0'
+        self.batch_size = 1000
+    
+    def process(self, pixel_id, events, test_event_code=None):
+        if not events:
+            return
+            
+        url = f"https://graph.facebook.com/{self.api_version}/{pixel_id}/events"
+        
+        for i in range(0, len(events), self.batch_size):
+            batch = events[i:i + self.batch_size]
+            
+            payload = {
+                "data": batch,
+                "access_token": self.access_token,
+                "partner_agent": "snowflake-cortex-code"
+            }
+            
+            if test_event_code:
+                payload["test_event_code"] = test_event_code
+            
+            try:
+                response = requests.post(
+                    url,
+                    json=payload,
+                    headers={"Content-Type": "application/json"},
+                    timeout=30
+                )
+                
+                result = response.json()
+                events_received = result.get('events_received', 0)
+                fbtrace_id = result.get('fbtrace_id', '')
+                
+                for event in batch:
+                    event_id = event.get('event_id', 'unknown')
+                    if response.status_code == 200:
+                        yield (event_id, 'SENT', result, events_received, fbtrace_id)
+                    else:
+                        yield (event_id, 'FAILED', result, 0, fbtrace_id)
+                        
+            except requests.exceptions.Timeout:
+                for event in batch:
+                    yield (event.get('event_id', 'unknown'), 'FAILED', 
+                           {"error": "Request timeout"}, 0, '')
+            except Exception as e:
+                for event in batch:
+                    yield (event.get('event_id', 'unknown'), 'FAILED', 
+                           {"error": str(e)}, 0, '')
+$$;
+"""

--- a/samples/meta-capi-pipeline/sql/03_monitoring/alerts.sql
+++ b/samples/meta-capi-pipeline/sql/03_monitoring/alerts.sql
@@ -1,0 +1,143 @@
+-- =============================================================================
+-- META CAPI ALERTING
+-- Procedures for detecting and alerting on pipeline issues
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- CHECK FOR ALERTS
+-- Returns any active alert conditions
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE check_capi_alerts()
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    alerts ARRAY DEFAULT ARRAY_CONSTRUCT();
+    pending_count INTEGER;
+    failed_24h INTEGER;
+    sent_24h INTEGER;
+    success_rate FLOAT;
+    hours_since_batch FLOAT;
+BEGIN
+    -- Check pending backlog
+    SELECT COUNT(*) INTO pending_count FROM META_CAPI_EVENTS WHERE STATUS = 'PENDING';
+    IF (pending_count > 10000) THEN
+        alerts := ARRAY_APPEND(alerts, OBJECT_CONSTRUCT(
+            'severity', 'WARNING',
+            'alert', 'HIGH_PENDING_BACKLOG',
+            'message', 'More than 10,000 events pending',
+            'value', pending_count
+        ));
+    END IF;
+    
+    -- Check success rate
+    SELECT COUNT(*) INTO failed_24h FROM META_CAPI_EVENTS 
+    WHERE STATUS = 'FAILED' AND PROCESSED_AT > DATEADD('hour', -24, CURRENT_TIMESTAMP());
+    
+    SELECT COUNT(*) INTO sent_24h FROM META_CAPI_EVENTS 
+    WHERE STATUS = 'SENT' AND PROCESSED_AT > DATEADD('hour', -24, CURRENT_TIMESTAMP());
+    
+    IF (sent_24h + failed_24h > 0) THEN
+        success_rate := (sent_24h * 100.0) / (sent_24h + failed_24h);
+        
+        IF (success_rate < 80) THEN
+            alerts := ARRAY_APPEND(alerts, OBJECT_CONSTRUCT(
+                'severity', 'CRITICAL',
+                'alert', 'LOW_SUCCESS_RATE',
+                'message', 'Success rate below 80%',
+                'value', ROUND(success_rate, 2)
+            ));
+        ELSEIF (success_rate < 95) THEN
+            alerts := ARRAY_APPEND(alerts, OBJECT_CONSTRUCT(
+                'severity', 'WARNING',
+                'alert', 'DEGRADED_SUCCESS_RATE',
+                'message', 'Success rate below 95%',
+                'value', ROUND(success_rate, 2)
+            ));
+        END IF;
+    END IF;
+    
+    -- Check for stale processing
+    SELECT DATEDIFF('hour', MAX(PROCESSED_AT), CURRENT_TIMESTAMP()) INTO hours_since_batch
+    FROM META_CAPI_LOG;
+    
+    IF (hours_since_batch > 2 AND pending_count > 0) THEN
+        alerts := ARRAY_APPEND(alerts, OBJECT_CONSTRUCT(
+            'severity', 'WARNING',
+            'alert', 'STALE_PROCESSING',
+            'message', 'No batches processed in over 2 hours with pending events',
+            'value', hours_since_batch
+        ));
+    END IF;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'alert_count', ARRAY_SIZE(alerts),
+        'alerts', alerts,
+        'checked_at', CURRENT_TIMESTAMP()
+    );
+END;
+$$;
+
+-- =============================================================================
+-- ALERT HISTORY TABLE
+-- Store historical alerts for trending
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS META_CAPI_ALERTS (
+    ALERT_ID NUMBER AUTOINCREMENT,
+    SEVERITY VARCHAR(20),
+    ALERT_TYPE VARCHAR(50),
+    MESSAGE VARCHAR(500),
+    VALUE VARIANT,
+    CREATED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    ACKNOWLEDGED_AT TIMESTAMP_NTZ,
+    ACKNOWLEDGED_BY VARCHAR(100),
+    PRIMARY KEY (ALERT_ID)
+);
+
+-- =============================================================================
+-- LOG ALERTS
+-- Captures current alerts to history
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE log_capi_alerts()
+RETURNS INTEGER
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    alert_result VARIANT;
+    alert_count INTEGER DEFAULT 0;
+    i INTEGER;
+    alert VARIANT;
+BEGIN
+    CALL check_capi_alerts() INTO alert_result;
+    
+    FOR i IN 0 TO ARRAY_SIZE(alert_result:alerts) - 1 DO
+        alert := alert_result:alerts[i];
+        
+        INSERT INTO META_CAPI_ALERTS (SEVERITY, ALERT_TYPE, MESSAGE, VALUE)
+        VALUES (
+            alert:severity::VARCHAR,
+            alert:alert::VARCHAR,
+            alert:message::VARCHAR,
+            alert:value
+        );
+        
+        alert_count := alert_count + 1;
+    END FOR;
+    
+    RETURN alert_count;
+END;
+$$;
+
+-- =============================================================================
+-- SCHEDULED ALERT CHECK (Optional)
+-- Run every 15 minutes
+-- =============================================================================
+-- CREATE OR REPLACE TASK meta_capi_alert_check
+--     WAREHOUSE = <WAREHOUSE>
+--     SCHEDULE = 'USING CRON */15 * * * * UTC'
+-- AS
+--     CALL log_capi_alerts();

--- a/samples/meta-capi-pipeline/sql/03_monitoring/health_check.sql
+++ b/samples/meta-capi-pipeline/sql/03_monitoring/health_check.sql
@@ -1,0 +1,141 @@
+-- =============================================================================
+-- META CAPI HEALTH CHECK QUERIES
+-- Monitoring and observability for the pipeline
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- HEALTH CHECK PROCEDURE
+-- Returns comprehensive pipeline status
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE capi_health_check()
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    pending_count INTEGER;
+    sent_24h INTEGER;
+    failed_24h INTEGER;
+    total_24h INTEGER;
+    success_rate FLOAT;
+    avg_per_hour FLOAT;
+    last_batch TIMESTAMP_NTZ;
+    task_state VARCHAR;
+BEGIN
+    -- Count pending
+    SELECT COUNT(*) INTO pending_count 
+    FROM META_CAPI_EVENTS WHERE STATUS = 'PENDING';
+    
+    -- Count sent in last 24h
+    SELECT COUNT(*) INTO sent_24h 
+    FROM META_CAPI_EVENTS 
+    WHERE STATUS = 'SENT' 
+    AND PROCESSED_AT > DATEADD('hour', -24, CURRENT_TIMESTAMP());
+    
+    -- Count failed in last 24h
+    SELECT COUNT(*) INTO failed_24h 
+    FROM META_CAPI_EVENTS 
+    WHERE STATUS = 'FAILED' 
+    AND PROCESSED_AT > DATEADD('hour', -24, CURRENT_TIMESTAMP());
+    
+    -- Calculate success rate
+    total_24h := sent_24h + failed_24h;
+    success_rate := CASE 
+        WHEN total_24h > 0 THEN ROUND((sent_24h * 100.0) / total_24h, 2)
+        ELSE 100.0
+    END;
+    
+    -- Average events per hour
+    avg_per_hour := ROUND(total_24h / 24.0, 1);
+    
+    -- Last batch time
+    SELECT MAX(PROCESSED_AT) INTO last_batch FROM META_CAPI_LOG;
+    
+    -- Task state
+    SELECT STATE INTO task_state 
+    FROM TABLE(INFORMATION_SCHEMA.TASK_HISTORY(
+        TASK_NAME => 'META_CAPI_SEND_EVENTS'
+    )) 
+    LIMIT 1;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'pending_events', pending_count,
+        'sent_24h', sent_24h,
+        'failed_24h', failed_24h,
+        'success_rate', success_rate,
+        'avg_events_per_hour', avg_per_hour,
+        'last_batch_time', last_batch,
+        'task_state', COALESCE(task_state, 'unknown')
+    );
+END;
+$$;
+
+-- =============================================================================
+-- SUMMARY VIEWS
+-- =============================================================================
+
+-- Events by status
+CREATE OR REPLACE VIEW V_EVENTS_BY_STATUS AS
+SELECT 
+    STATUS,
+    COUNT(*) AS EVENT_COUNT,
+    MIN(CREATED_AT) AS OLDEST_EVENT,
+    MAX(CREATED_AT) AS NEWEST_EVENT
+FROM META_CAPI_EVENTS
+GROUP BY STATUS;
+
+-- Events by type (last 7 days)
+CREATE OR REPLACE VIEW V_EVENTS_BY_TYPE AS
+SELECT 
+    EVENT_NAME,
+    COUNT(*) AS EVENT_COUNT,
+    COUNT(CASE WHEN STATUS = 'SENT' THEN 1 END) AS SENT_COUNT,
+    COUNT(CASE WHEN STATUS = 'FAILED' THEN 1 END) AS FAILED_COUNT
+FROM META_CAPI_EVENTS
+WHERE CREATED_AT > DATEADD('day', -7, CURRENT_TIMESTAMP())
+GROUP BY EVENT_NAME
+ORDER BY EVENT_COUNT DESC;
+
+-- Hourly throughput
+CREATE OR REPLACE VIEW V_HOURLY_THROUGHPUT AS
+SELECT 
+    DATE_TRUNC('hour', PROCESSED_AT) AS HOUR,
+    COUNT(*) AS TOTAL_EVENTS,
+    COUNT(CASE WHEN STATUS = 'SENT' THEN 1 END) AS SENT,
+    COUNT(CASE WHEN STATUS = 'FAILED' THEN 1 END) AS FAILED
+FROM META_CAPI_EVENTS
+WHERE PROCESSED_AT > DATEADD('day', -7, CURRENT_TIMESTAMP())
+GROUP BY DATE_TRUNC('hour', PROCESSED_AT)
+ORDER BY HOUR DESC;
+
+-- Recent batches
+CREATE OR REPLACE VIEW V_RECENT_BATCHES AS
+SELECT 
+    BATCH_ID,
+    MIN(PROCESSED_AT) AS BATCH_TIME,
+    COUNT(*) AS EVENT_COUNT,
+    COUNT(CASE WHEN STATUS = 'SENT' THEN 1 END) AS SENT,
+    COUNT(CASE WHEN STATUS = 'FAILED' THEN 1 END) AS FAILED
+FROM META_CAPI_LOG
+WHERE PROCESSED_AT > DATEADD('day', -1, CURRENT_TIMESTAMP())
+GROUP BY BATCH_ID
+ORDER BY BATCH_TIME DESC
+LIMIT 20;
+
+-- =============================================================================
+-- QUICK STATUS QUERIES
+-- =============================================================================
+
+-- Current status summary
+-- SELECT * FROM V_EVENTS_BY_STATUS;
+
+-- Events by type
+-- SELECT * FROM V_EVENTS_BY_TYPE;
+
+-- Last 24 hours throughput
+-- SELECT * FROM V_HOURLY_THROUGHPUT WHERE HOUR > DATEADD('day', -1, CURRENT_TIMESTAMP());
+
+-- Recent batch results
+-- SELECT * FROM V_RECENT_BATCHES;

--- a/samples/meta-capi-pipeline/sql/04_troubleshooting/error_handling.sql
+++ b/samples/meta-capi-pipeline/sql/04_troubleshooting/error_handling.sql
@@ -1,0 +1,188 @@
+-- =============================================================================
+-- META CAPI ERROR HANDLING
+-- Recovery and retry procedures
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- RETRY FAILED EVENTS
+-- Resets failed events for reprocessing with retry limits
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE retry_failed_events(
+    max_retries INTEGER DEFAULT 3,
+    batch_limit INTEGER DEFAULT 1000
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    updated_count INTEGER;
+    skipped_count INTEGER;
+BEGIN
+    -- Count events that exceeded retry limit
+    SELECT COUNT(*) INTO skipped_count
+    FROM META_CAPI_EVENTS
+    WHERE STATUS = 'FAILED' AND RETRY_COUNT >= :max_retries;
+    
+    -- Reset eligible failed events
+    UPDATE META_CAPI_EVENTS
+    SET 
+        STATUS = 'PENDING',
+        RETRY_COUNT = RETRY_COUNT + 1,
+        ERROR_MESSAGE = NULL,
+        META_RESPONSE = NULL,
+        PROCESSED_AT = NULL
+    WHERE STATUS = 'FAILED'
+    AND RETRY_COUNT < :max_retries
+    LIMIT :batch_limit;
+    
+    SELECT COUNT(*) INTO updated_count
+    FROM META_CAPI_EVENTS
+    WHERE STATUS = 'PENDING' AND RETRY_COUNT > 0;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'events_reset', updated_count,
+        'events_skipped', skipped_count,
+        'max_retries', max_retries,
+        'timestamp', CURRENT_TIMESTAMP()
+    );
+END;
+$$;
+
+-- =============================================================================
+-- QUARANTINE PERMANENT FAILURES
+-- Move events that exceed retry limit to quarantine
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS META_CAPI_QUARANTINE (
+    EVENT_ID VARCHAR(100),
+    EVENT_NAME VARCHAR(50),
+    EVENT_TIME TIMESTAMP_NTZ,
+    ACTION_SOURCE VARCHAR(20),
+    LAST_ERROR VARCHAR(2000),
+    RETRY_COUNT INTEGER,
+    QUARANTINED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    EVENT_DATA VARIANT
+);
+
+CREATE OR REPLACE PROCEDURE quarantine_failed_events(max_retries INTEGER DEFAULT 3)
+RETURNS INTEGER
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    quarantine_count INTEGER;
+BEGIN
+    -- Move to quarantine
+    INSERT INTO META_CAPI_QUARANTINE (EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, LAST_ERROR, RETRY_COUNT, EVENT_DATA)
+    SELECT 
+        EVENT_ID,
+        EVENT_NAME,
+        EVENT_TIME,
+        ACTION_SOURCE,
+        ERROR_MESSAGE,
+        RETRY_COUNT,
+        OBJECT_CONSTRUCT(
+            'em', EM, 'ph', PH, 'fn', FN, 'ln', LN,
+            'value', VALUE, 'currency', CURRENCY,
+            'content_ids', CONTENT_IDS,
+            'meta_response', META_RESPONSE
+        )
+    FROM META_CAPI_EVENTS
+    WHERE STATUS = 'FAILED' AND RETRY_COUNT >= :max_retries;
+    
+    -- Delete from main table
+    DELETE FROM META_CAPI_EVENTS
+    WHERE STATUS = 'FAILED' AND RETRY_COUNT >= :max_retries;
+    
+    SELECT COUNT(*) INTO quarantine_count FROM META_CAPI_QUARANTINE;
+    
+    RETURN quarantine_count;
+END;
+$$;
+
+-- =============================================================================
+-- ERROR ANALYSIS
+-- Group errors by type for pattern detection
+-- =============================================================================
+CREATE OR REPLACE VIEW V_ERROR_ANALYSIS AS
+SELECT 
+    COALESCE(
+        META_RESPONSE:error:message::VARCHAR,
+        META_RESPONSE:error::VARCHAR,
+        ERROR_MESSAGE,
+        'Unknown error'
+    ) AS ERROR_TYPE,
+    COUNT(*) AS ERROR_COUNT,
+    MIN(PROCESSED_AT) AS FIRST_OCCURRENCE,
+    MAX(PROCESSED_AT) AS LAST_OCCURRENCE,
+    ARRAY_AGG(EVENT_ID) WITHIN GROUP (ORDER BY PROCESSED_AT DESC) AS SAMPLE_EVENT_IDS
+FROM META_CAPI_EVENTS
+WHERE STATUS = 'FAILED'
+GROUP BY ERROR_TYPE
+ORDER BY ERROR_COUNT DESC;
+
+-- =============================================================================
+-- RESET SPECIFIC EVENTS
+-- Manually reset events by ID
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE reset_events_by_id(event_ids ARRAY)
+RETURNS INTEGER
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    reset_count INTEGER;
+BEGIN
+    UPDATE META_CAPI_EVENTS
+    SET 
+        STATUS = 'PENDING',
+        ERROR_MESSAGE = NULL,
+        META_RESPONSE = NULL,
+        PROCESSED_AT = NULL
+    WHERE EVENT_ID IN (SELECT VALUE FROM TABLE(FLATTEN(INPUT => :event_ids)));
+    
+    SELECT COUNT(*) INTO reset_count
+    FROM META_CAPI_EVENTS
+    WHERE EVENT_ID IN (SELECT VALUE FROM TABLE(FLATTEN(INPUT => :event_ids)))
+    AND STATUS = 'PENDING';
+    
+    RETURN reset_count;
+END;
+$$;
+
+-- =============================================================================
+-- PURGE OLD DATA
+-- Clean up old logs and processed events
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE purge_old_data(retention_days INTEGER DEFAULT 30)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    deleted_logs INTEGER;
+    deleted_events INTEGER;
+BEGIN
+    -- Delete old logs
+    DELETE FROM META_CAPI_LOG
+    WHERE PROCESSED_AT < DATEADD('day', -:retention_days, CURRENT_TIMESTAMP());
+    
+    SELECT ROW_COUNT() INTO deleted_logs;
+    
+    -- Delete old sent events (keep failed for analysis)
+    DELETE FROM META_CAPI_EVENTS
+    WHERE STATUS = 'SENT'
+    AND PROCESSED_AT < DATEADD('day', -:retention_days, CURRENT_TIMESTAMP());
+    
+    SELECT ROW_COUNT() INTO deleted_events;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'deleted_logs', deleted_logs,
+        'deleted_events', deleted_events,
+        'retention_days', retention_days,
+        'timestamp', CURRENT_TIMESTAMP()
+    );
+END;
+$$;

--- a/samples/meta-capi-pipeline/sql/04_troubleshooting/validation.sql
+++ b/samples/meta-capi-pipeline/sql/04_troubleshooting/validation.sql
@@ -1,0 +1,153 @@
+-- =============================================================================
+-- META CAPI DATA VALIDATION
+-- Validate event data before sending to Meta
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- COMPREHENSIVE VALIDATION VIEW
+-- =============================================================================
+CREATE OR REPLACE VIEW V_CAPI_VALIDATION_DETAIL AS
+SELECT 
+    EVENT_ID,
+    EVENT_NAME,
+    EVENT_TIME,
+    ACTION_SOURCE,
+    
+    -- Required field checks
+    CASE WHEN EVENT_NAME IS NULL THEN 'FAIL' ELSE 'PASS' END AS CHK_EVENT_NAME,
+    CASE WHEN EVENT_TIME IS NULL THEN 'FAIL' ELSE 'PASS' END AS CHK_EVENT_TIME,
+    CASE WHEN ACTION_SOURCE IS NULL THEN 'FAIL' ELSE 'PASS' END AS CHK_ACTION_SOURCE,
+    
+    -- Website-specific checks
+    CASE 
+        WHEN ACTION_SOURCE = 'website' AND EVENT_SOURCE_URL IS NULL THEN 'FAIL'
+        WHEN ACTION_SOURCE = 'website' THEN 'PASS'
+        ELSE 'N/A'
+    END AS CHK_SOURCE_URL,
+    
+    CASE 
+        WHEN ACTION_SOURCE = 'website' AND CLIENT_USER_AGENT IS NULL THEN 'FAIL'
+        WHEN ACTION_SOURCE = 'website' THEN 'PASS'
+        ELSE 'N/A'
+    END AS CHK_USER_AGENT,
+    
+    -- Value/currency checks
+    CASE 
+        WHEN EVENT_NAME IN ('Purchase', 'Donate', 'StartTrial', 'Subscribe') AND VALUE IS NULL THEN 'FAIL'
+        ELSE 'PASS'
+    END AS CHK_VALUE_REQUIRED,
+    
+    CASE 
+        WHEN VALUE IS NOT NULL AND CURRENCY IS NULL THEN 'FAIL'
+        ELSE 'PASS'
+    END AS CHK_CURRENCY,
+    
+    -- PII quality checks
+    CASE 
+        WHEN EM IS NOT NULL AND LENGTH(EM) != 64 THEN 'WARN'
+        ELSE 'PASS'
+    END AS CHK_EMAIL_HASH,
+    
+    CASE 
+        WHEN PH IS NOT NULL AND LENGTH(PH) != 64 THEN 'WARN'
+        ELSE 'PASS'
+    END AS CHK_PHONE_HASH,
+    
+    -- Match quality score
+    CASE 
+        WHEN EM IS NOT NULL OR PH IS NOT NULL THEN 'GOOD'
+        WHEN FBP IS NOT NULL OR FBC IS NOT NULL THEN 'MODERATE'
+        WHEN CLIENT_IP_ADDRESS IS NOT NULL AND CLIENT_USER_AGENT IS NOT NULL THEN 'LOW'
+        ELSE 'POOR'
+    END AS MATCH_QUALITY,
+    
+    STATUS,
+    CREATED_AT
+    
+FROM META_CAPI_EVENTS
+WHERE STATUS = 'PENDING';
+
+-- =============================================================================
+-- VALIDATION SUMMARY
+-- =============================================================================
+CREATE OR REPLACE VIEW V_VALIDATION_SUMMARY AS
+SELECT 
+    COUNT(*) AS TOTAL_PENDING,
+    COUNT(CASE WHEN CHK_EVENT_NAME = 'FAIL' THEN 1 END) AS MISSING_EVENT_NAME,
+    COUNT(CASE WHEN CHK_EVENT_TIME = 'FAIL' THEN 1 END) AS MISSING_EVENT_TIME,
+    COUNT(CASE WHEN CHK_ACTION_SOURCE = 'FAIL' THEN 1 END) AS MISSING_ACTION_SOURCE,
+    COUNT(CASE WHEN CHK_SOURCE_URL = 'FAIL' THEN 1 END) AS MISSING_SOURCE_URL,
+    COUNT(CASE WHEN CHK_USER_AGENT = 'FAIL' THEN 1 END) AS MISSING_USER_AGENT,
+    COUNT(CASE WHEN CHK_VALUE_REQUIRED = 'FAIL' THEN 1 END) AS MISSING_VALUE,
+    COUNT(CASE WHEN CHK_CURRENCY = 'FAIL' THEN 1 END) AS MISSING_CURRENCY,
+    COUNT(CASE WHEN MATCH_QUALITY = 'GOOD' THEN 1 END) AS HIGH_MATCH_EVENTS,
+    COUNT(CASE WHEN MATCH_QUALITY = 'POOR' THEN 1 END) AS LOW_MATCH_EVENTS
+FROM V_CAPI_VALIDATION_DETAIL;
+
+-- =============================================================================
+-- VALIDATE EVENT PROCEDURE
+-- Returns specific validation errors
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE validate_pending_events()
+RETURNS TABLE (
+    event_id VARCHAR,
+    event_name VARCHAR,
+    check_name VARCHAR,
+    status VARCHAR,
+    message VARCHAR
+)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+BEGIN
+    res := (
+        SELECT 
+            EVENT_ID,
+            EVENT_NAME,
+            CHECK_NAME,
+            CHECK_STATUS,
+            MESSAGE
+        FROM (
+            SELECT EVENT_ID, EVENT_NAME, 'EVENT_NAME' AS CHECK_NAME, CHK_EVENT_NAME AS CHECK_STATUS, 'Event name is required' AS MESSAGE FROM V_CAPI_VALIDATION_DETAIL WHERE CHK_EVENT_NAME = 'FAIL'
+            UNION ALL
+            SELECT EVENT_ID, EVENT_NAME, 'EVENT_TIME', CHK_EVENT_TIME, 'Event time is required' FROM V_CAPI_VALIDATION_DETAIL WHERE CHK_EVENT_TIME = 'FAIL'
+            UNION ALL
+            SELECT EVENT_ID, EVENT_NAME, 'ACTION_SOURCE', CHK_ACTION_SOURCE, 'Action source is required' FROM V_CAPI_VALIDATION_DETAIL WHERE CHK_ACTION_SOURCE = 'FAIL'
+            UNION ALL
+            SELECT EVENT_ID, EVENT_NAME, 'SOURCE_URL', CHK_SOURCE_URL, 'Website events require event_source_url' FROM V_CAPI_VALIDATION_DETAIL WHERE CHK_SOURCE_URL = 'FAIL'
+            UNION ALL
+            SELECT EVENT_ID, EVENT_NAME, 'USER_AGENT', CHK_USER_AGENT, 'Website events require client_user_agent' FROM V_CAPI_VALIDATION_DETAIL WHERE CHK_USER_AGENT = 'FAIL'
+            UNION ALL
+            SELECT EVENT_ID, EVENT_NAME, 'VALUE', CHK_VALUE_REQUIRED, 'Value is required for this event type' FROM V_CAPI_VALIDATION_DETAIL WHERE CHK_VALUE_REQUIRED = 'FAIL'
+            UNION ALL
+            SELECT EVENT_ID, EVENT_NAME, 'CURRENCY', CHK_CURRENCY, 'Currency is required when value is set' FROM V_CAPI_VALIDATION_DETAIL WHERE CHK_CURRENCY = 'FAIL'
+        )
+        ORDER BY EVENT_ID, CHECK_NAME
+    );
+    RETURN TABLE(res);
+END;
+$$;
+
+-- =============================================================================
+-- HASH VALIDATION
+-- Check if PII fields are properly hashed (SHA256 = 64 hex chars)
+-- =============================================================================
+CREATE OR REPLACE VIEW V_HASH_VALIDATION AS
+SELECT 
+    EVENT_ID,
+    CASE WHEN EM IS NOT NULL AND LENGTH(EM) != 64 THEN 'Invalid email hash length: ' || LENGTH(EM) END AS EMAIL_ISSUE,
+    CASE WHEN PH IS NOT NULL AND LENGTH(PH) != 64 THEN 'Invalid phone hash length: ' || LENGTH(PH) END AS PHONE_ISSUE,
+    CASE WHEN FN IS NOT NULL AND LENGTH(FN) != 64 THEN 'Invalid first name hash length: ' || LENGTH(FN) END AS FN_ISSUE,
+    CASE WHEN LN IS NOT NULL AND LENGTH(LN) != 64 THEN 'Invalid last name hash length: ' || LENGTH(LN) END AS LN_ISSUE
+FROM META_CAPI_EVENTS
+WHERE STATUS = 'PENDING'
+AND (
+    (EM IS NOT NULL AND LENGTH(EM) != 64) OR
+    (PH IS NOT NULL AND LENGTH(PH) != 64) OR
+    (FN IS NOT NULL AND LENGTH(FN) != 64) OR
+    (LN IS NOT NULL AND LENGTH(LN) != 64)
+);

--- a/samples/meta-capi-pipeline/sql/05_recommendations/reco_discovery.sql
+++ b/samples/meta-capi-pipeline/sql/05_recommendations/reco_discovery.sql
@@ -1,0 +1,223 @@
+-- =============================================================================
+-- RECOMMENDATION-DRIVEN TABLE DISCOVERY
+-- Finds tables that match pending Meta recommendations
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- PROCEDURE: Discover tables matching pending recommendations
+-- Returns tables grouped by which Meta use case they can satisfy
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE discover_tables_for_recommendations(
+    search_database VARCHAR DEFAULT NULL,
+    search_schema VARCHAR DEFAULT NULL
+)
+RETURNS TABLE (
+    use_case_name VARCHAR,
+    use_case_ref VARCHAR,
+    required_event_type VARCHAR,
+    required_parameters VARCHAR,
+    database_name VARCHAR,
+    schema_name VARCHAR,
+    table_name VARCHAR,
+    match_score INTEGER,
+    matched_columns ARRAY,
+    missing_required ARRAY,
+    fit_assessment VARCHAR
+)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+BEGIN
+    res := (
+        WITH pending_recos AS (
+            SELECT 
+                RECOMMENDATION_ID,
+                USE_CASE_NAME,
+                USE_CASE_REF,
+                PRIMARY_EVENT_TYPE,
+                REQUIRED_PARAMETERS,
+                DESCRIPTION
+            FROM V_PENDING_RECOMMENDATIONS
+        ),
+        table_column_analysis AS (
+            SELECT 
+                c.TABLE_CATALOG AS DB,
+                c.TABLE_SCHEMA AS SCH,
+                c.TABLE_NAME AS TBL,
+                COUNT(DISTINCT CASE 
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%email%', '%mail%', 'em') THEN 'email'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%phone%', '%mobile%', 'ph') THEN 'phone'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%first%name%', 'fname', 'fn') THEN 'first_name'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%last%name%', 'lname', 'ln') THEN 'last_name'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%value%', '%amount%', '%total%', '%revenue%', '%price%') THEN 'value'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%currency%', 'curr') THEN 'currency'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%time%', '%date%', '%created%', '%timestamp%') THEN 'event_time'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%order%id%', '%transaction%id%') THEN 'order_id'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%user%id%', '%customer%id%', '%external%id%') THEN 'external_id'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%ip%', '%client%ip%') THEN 'ip_address'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%agent%', '%browser%', '%user%agent%') THEN 'user_agent'
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%ltv%', '%lifetime%value%', '%predicted%') THEN 'predicted_ltv'
+                END) AS MATCH_SCORE,
+                ARRAY_AGG(DISTINCT CASE 
+                    WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%email%', '%phone%', '%first%name%', '%last%name%', 
+                        '%value%', '%amount%', '%total%', '%time%', '%date%', '%order%id%', '%user%id%',
+                        '%ltv%', '%lifetime%', '%predicted%') 
+                    THEN c.COLUMN_NAME 
+                END) AS MATCHED_COLUMNS,
+                MAX(CASE WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%value%', '%amount%', '%total%', '%revenue%', '%price%') THEN 1 ELSE 0 END) AS HAS_VALUE,
+                MAX(CASE WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%time%', '%date%', '%created%', '%timestamp%') THEN 1 ELSE 0 END) AS HAS_TIME,
+                MAX(CASE WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%ltv%', '%lifetime%value%', '%predicted%') THEN 1 ELSE 0 END) AS HAS_LTV,
+                MAX(CASE WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%email%', '%mail%') THEN 1 ELSE 0 END) AS HAS_EMAIL,
+                MAX(CASE WHEN LOWER(c.COLUMN_NAME) LIKE ANY ('%event%id%') THEN 1 ELSE 0 END) AS HAS_EVENT_ID
+            FROM INFORMATION_SCHEMA.COLUMNS c
+            WHERE (c.TABLE_CATALOG = :search_database OR :search_database IS NULL)
+            AND (c.TABLE_SCHEMA = :search_schema OR :search_schema IS NULL)
+            AND c.TABLE_SCHEMA NOT IN ('INFORMATION_SCHEMA')
+            GROUP BY c.TABLE_CATALOG, c.TABLE_SCHEMA, c.TABLE_NAME
+            HAVING MATCH_SCORE >= 2
+        ),
+        matched_tables AS (
+            SELECT 
+                r.USE_CASE_NAME,
+                r.USE_CASE_REF,
+                r.PRIMARY_EVENT_TYPE AS REQUIRED_EVENT_TYPE,
+                (SELECT LISTAGG(p.value:key::VARCHAR, ', ') 
+                 FROM TABLE(FLATTEN(r.REQUIRED_PARAMETERS)) p) AS REQUIRED_PARAMETERS,
+                t.DB AS DATABASE_NAME,
+                t.SCH AS SCHEMA_NAME,
+                t.TBL AS TABLE_NAME,
+                t.MATCH_SCORE,
+                t.MATCHED_COLUMNS,
+                CASE 
+                    WHEN r.PRIMARY_EVENT_TYPE = 'Purchase' AND t.HAS_VALUE = 0 
+                        THEN ARRAY_CONSTRUCT('value (required for Purchase events)')
+                    WHEN r.PRIMARY_EVENT_TYPE = 'AppendValue' AND t.HAS_LTV = 0 
+                        THEN ARRAY_CONSTRUCT('predicted_ltv (required for pLTV)')
+                    WHEN r.PRIMARY_EVENT_TYPE = 'AppendValue' AND t.HAS_EVENT_ID = 0 
+                        THEN ARRAY_CONSTRUCT('event_id (required for AppendValue)')
+                    ELSE ARRAY_CONSTRUCT()
+                END AS MISSING_REQUIRED,
+                CASE 
+                    WHEN t.MATCH_SCORE >= 5 AND ARRAY_SIZE(MISSING_REQUIRED) = 0 THEN 'EXCELLENT'
+                    WHEN t.MATCH_SCORE >= 4 AND ARRAY_SIZE(MISSING_REQUIRED) = 0 THEN 'GOOD'
+                    WHEN t.MATCH_SCORE >= 3 THEN 'MODERATE'
+                    ELSE 'LOW'
+                END AS FIT_ASSESSMENT
+            FROM pending_recos r
+            CROSS JOIN table_column_analysis t
+            WHERE 
+                (r.PRIMARY_EVENT_TYPE = 'Purchase' AND t.HAS_VALUE = 1 AND t.HAS_TIME = 1)
+                OR (r.PRIMARY_EVENT_TYPE = 'Lead' AND t.HAS_EMAIL = 1)
+                OR (r.PRIMARY_EVENT_TYPE = 'AppendValue' AND (t.HAS_LTV = 1 OR t.HAS_VALUE = 1))
+                OR (r.PRIMARY_EVENT_TYPE NOT IN ('Purchase', 'Lead', 'AppendValue') AND t.MATCH_SCORE >= 2)
+        )
+        SELECT 
+            USE_CASE_NAME,
+            USE_CASE_REF,
+            REQUIRED_EVENT_TYPE,
+            REQUIRED_PARAMETERS,
+            DATABASE_NAME,
+            SCHEMA_NAME,
+            TABLE_NAME,
+            MATCH_SCORE,
+            MATCHED_COLUMNS,
+            MISSING_REQUIRED,
+            FIT_ASSESSMENT
+        FROM matched_tables
+        ORDER BY 
+            USE_CASE_NAME,
+            CASE FIT_ASSESSMENT 
+                WHEN 'EXCELLENT' THEN 1 
+                WHEN 'GOOD' THEN 2 
+                WHEN 'MODERATE' THEN 3 
+                ELSE 4 
+            END,
+            MATCH_SCORE DESC
+    );
+    RETURN TABLE(res);
+END;
+$$;
+
+-- =============================================================================
+-- PROCEDURE: Get detailed column mapping for a specific table and use case
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE analyze_table_for_recommendation(
+    use_case_ref VARCHAR,
+    source_database VARCHAR,
+    source_schema VARCHAR,
+    source_table VARCHAR
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    meta_req VARIANT;
+    column_analysis VARIANT;
+BEGIN
+    SELECT OBJECT_CONSTRUCT(
+        'use_case_name', USE_CASE_NAME,
+        'use_case_ref', USE_CASE_REF,
+        'description', DESCRIPTION,
+        'required_events', REQUIRED_EVENTS,
+        'recommended_events', RECOMMENDED_EVENTS
+    ) INTO meta_req
+    FROM V_PENDING_RECOMMENDATIONS
+    WHERE USE_CASE_REF = :use_case_ref
+    LIMIT 1;
+    
+    SELECT ARRAY_AGG(OBJECT_CONSTRUCT(
+        'source_column', COLUMN_NAME,
+        'data_type', DATA_TYPE,
+        'suggested_target', 
+        CASE 
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%mail%', 'em') THEN 'em'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%phone%', '%mobile%', 'ph') THEN 'ph'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%first%name%', 'fname', 'fn') THEN 'fn'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%last%name%', 'lname', 'ln') THEN 'ln'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%value%', '%amount%', '%total%', '%revenue%') THEN 'value'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%currency%') THEN 'currency'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%time%', '%date%', '%created%', '%timestamp%') THEN 'event_time'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%order%id%', '%transaction%id%') THEN 'order_id'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%user%id%', '%customer%id%') THEN 'external_id'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%ip%') THEN 'client_ip_address'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%agent%', '%browser%') THEN 'client_user_agent'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%ltv%', '%lifetime%', '%predicted%') THEN 'predicted_ltv'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%city%') THEN 'ct'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%state%', '%province%') THEN 'st'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%zip%', '%postal%') THEN 'zp'
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%country%') THEN 'country'
+            ELSE NULL
+        END,
+        'requires_hashing',
+        CASE 
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%phone%', '%first%', '%last%', '%city%', '%state%', '%zip%', '%country%') THEN TRUE
+            ELSE FALSE
+        END,
+        'is_pii',
+        CASE 
+            WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%phone%', '%name%', '%address%', '%city%', '%state%', '%zip%') THEN TRUE
+            ELSE FALSE
+        END
+    )) INTO column_analysis
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_CATALOG = :source_database
+    AND TABLE_SCHEMA = :source_schema
+    AND TABLE_NAME = :source_table;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'meta_requirements', meta_req,
+        'source', OBJECT_CONSTRUCT(
+            'database', source_database,
+            'schema', source_schema,
+            'table', source_table
+        ),
+        'column_analysis', column_analysis,
+        'next_step', 'CALL generate_reco_config(''' || use_case_ref || ''', ''' || source_database || ''', ''' || source_schema || ''', ''' || source_table || ''')'
+    );
+END;
+$$;

--- a/samples/meta-capi-pipeline/sql/05_recommendations/reco_pipeline_config.sql
+++ b/samples/meta-capi-pipeline/sql/05_recommendations/reco_pipeline_config.sql
@@ -1,0 +1,521 @@
+-- =============================================================================
+-- RECOMMENDATION PIPELINE CONFIGS
+-- Separate from PIPELINE_CONFIGS - never edits existing pipelines
+-- Human-in-the-loop workflow for deploying recommendation-based pipelines
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- TABLE: Dedicated config table for recommendation-based pipelines
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS META_RECO_CONFIGS (
+    CONFIG_ID VARCHAR(100) DEFAULT UUID_STRING() PRIMARY KEY,
+    CONFIG_NAME VARCHAR(200),
+    
+    RECOMMENDATION_ID VARCHAR(100),
+    USE_CASE_REF VARCHAR(100),
+    USE_CASE_NAME VARCHAR(200),
+    
+    SOURCE_DATABASE VARCHAR(100),
+    SOURCE_SCHEMA VARCHAR(100),
+    SOURCE_TABLE VARCHAR(100),
+    
+    CONFIG VARIANT,
+    
+    STATUS VARCHAR(20) DEFAULT 'PENDING_REVIEW',
+    CREATED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    CREATED_BY VARCHAR(100) DEFAULT CURRENT_USER(),
+    REVIEWED_AT TIMESTAMP_NTZ,
+    REVIEWED_BY VARCHAR(100),
+    REVIEW_NOTES VARCHAR(2000),
+    APPROVED_AT TIMESTAMP_NTZ,
+    APPROVED_BY VARCHAR(100),
+    APPROVAL_NOTES VARCHAR(2000),
+    DEPLOYED_AT TIMESTAMP_NTZ,
+    DEPLOYED_BY VARCHAR(100),
+    
+    DEPLOYED_OBJECTS VARIANT
+);
+
+-- =============================================================================
+-- PROCEDURE: Generate config for review (creates NO objects)
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE generate_reco_config(
+    use_case_ref VARCHAR,
+    source_database VARCHAR,
+    source_schema VARCHAR,
+    source_table VARCHAR
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    config VARIANT;
+    meta_req VARIANT;
+    reco_id VARCHAR;
+    reco_name VARCHAR;
+BEGIN
+    SELECT 
+        RECOMMENDATION_ID,
+        USE_CASE_NAME,
+        OBJECT_CONSTRUCT(
+            'use_case_name', USE_CASE_NAME,
+            'use_case_ref', USE_CASE_REF,
+            'description', DESCRIPTION,
+            'event_type', PRIMARY_EVENT_TYPE,
+            'required_parameters', REQUIRED_PARAMETERS,
+            'recommended_events', RECOMMENDED_EVENTS
+        )
+    INTO reco_id, reco_name, meta_req
+    FROM V_PENDING_RECOMMENDATIONS
+    WHERE USE_CASE_REF = :use_case_ref
+    LIMIT 1;
+    
+    IF (reco_id IS NULL) THEN
+        RETURN OBJECT_CONSTRUCT(
+            'status', 'ERROR',
+            'message', 'No pending recommendation found for use_case_ref: ' || use_case_ref,
+            'action', 'Run CALL get_use_case_recommendations() first'
+        );
+    END IF;
+    
+    SELECT OBJECT_CONSTRUCT(
+        '_metadata', OBJECT_CONSTRUCT(
+            'generated_at', CURRENT_TIMESTAMP(),
+            'generated_by', CURRENT_USER(),
+            'status', 'PENDING_REVIEW',
+            'recommendation_id', :reco_id,
+            'use_case_ref', :use_case_ref,
+            'instructions', 'Review column mappings, verify PII fields, then call save_reco_config() to persist'
+        ),
+        'meta_requirements', :meta_req,
+        'source', OBJECT_CONSTRUCT(
+            'database', :source_database,
+            'schema', :source_schema,
+            'table', :source_table,
+            'full_path', :source_database || '.' || :source_schema || '.' || :source_table
+        ),
+        'target', OBJECT_CONSTRUCT(
+            'database', 'META_CAPI_DB',
+            'schema', 'PIPELINE',
+            'table', 'META_CAPI_EVENTS'
+        ),
+        'event_settings', OBJECT_CONSTRUCT(
+            'event_type', meta_req:event_type::VARCHAR,
+            'action_source', 'website'
+        ),
+        'column_mappings', (
+            SELECT ARRAY_AGG(OBJECT_CONSTRUCT(
+                'source_column', COLUMN_NAME,
+                'source_type', DATA_TYPE,
+                'target_field', 
+                CASE 
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%mail%', 'em') THEN 'EM'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%phone%', '%mobile%', 'ph') THEN 'PH'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%first%name%', 'fname', 'fn') THEN 'FN'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%last%name%', 'lname', 'ln') THEN 'LN'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%value%', '%amount%', '%total%', '%revenue%') THEN 'VALUE'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%currency%') THEN 'CURRENCY'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%time%', '%date%', '%created%', '%timestamp%') THEN 'EVENT_TIME'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%order%id%', '%transaction%id%') THEN 'ORDER_ID'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%user%id%', '%customer%id%') THEN 'EXTERNAL_ID'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%ip%') THEN 'CLIENT_IP_ADDRESS'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%agent%', '%browser%') THEN 'CLIENT_USER_AGENT'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%ltv%', '%lifetime%', '%predicted%') THEN 'PREDICTED_LTV'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%city%') THEN 'CT'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%state%', '%province%') THEN 'ST'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%zip%', '%postal%') THEN 'ZP'
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%country%') THEN 'COUNTRY'
+                    ELSE NULL
+                END,
+                'requires_hashing',
+                CASE 
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%phone%', '%first%', '%last%', '%city%', '%state%', '%zip%', '%country%') THEN TRUE
+                    ELSE FALSE
+                END,
+                'include',
+                CASE 
+                    WHEN LOWER(COLUMN_NAME) LIKE ANY ('%email%', '%phone%', '%first%', '%last%', '%value%', '%amount%', '%total%', '%time%', '%date%', '%order%', '%user%id%', '%customer%', '%ltv%', '%predicted%') THEN TRUE
+                    ELSE FALSE
+                END,
+                'notes', ''
+            ))
+            FROM INFORMATION_SCHEMA.COLUMNS
+            WHERE TABLE_CATALOG = :source_database
+            AND TABLE_SCHEMA = :source_schema
+            AND TABLE_NAME = :source_table
+        ),
+        'pipeline_settings', OBJECT_CONSTRUCT(
+            'pipeline_name', 'RECO_' || UPPER(REPLACE(:use_case_ref, ' ', '_')),
+            'schedule', 'ON_NEW_DATA',
+            'batch_size', 10000,
+            'enabled', FALSE
+        ),
+        'review_checklist', ARRAY_CONSTRUCT(
+            OBJECT_CONSTRUCT('check', 'Verify all Meta required parameters are mapped', 'completed', FALSE),
+            OBJECT_CONSTRUCT('check', 'Confirm PII columns are set for SHA256 hashing', 'completed', FALSE),
+            OBJECT_CONSTRUCT('check', 'Check event_type matches Meta recommendation', 'completed', FALSE),
+            OBJECT_CONSTRUCT('check', 'Verify action_source is correct (website/app/etc)', 'completed', FALSE)
+        )
+    ) INTO config;
+    
+    RETURN config;
+END;
+$$;
+
+-- =============================================================================
+-- PROCEDURE: Save config for team review
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE save_reco_config(
+    config VARIANT,
+    config_name VARCHAR DEFAULT NULL
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    config_id VARCHAR;
+    name VARCHAR;
+BEGIN
+    config_id := UUID_STRING();
+    name := COALESCE(:config_name, config:pipeline_settings:pipeline_name::VARCHAR);
+    
+    INSERT INTO META_RECO_CONFIGS (
+        CONFIG_ID,
+        CONFIG_NAME,
+        RECOMMENDATION_ID,
+        USE_CASE_REF,
+        USE_CASE_NAME,
+        SOURCE_DATABASE,
+        SOURCE_SCHEMA,
+        SOURCE_TABLE,
+        CONFIG,
+        STATUS,
+        CREATED_BY
+    )
+    VALUES (
+        :config_id,
+        :name,
+        config:_metadata:recommendation_id::VARCHAR,
+        config:_metadata:use_case_ref::VARCHAR,
+        config:meta_requirements:use_case_name::VARCHAR,
+        config:source:database::VARCHAR,
+        config:source:schema::VARCHAR,
+        config:source:table::VARCHAR,
+        :config,
+        'PENDING_REVIEW',
+        CURRENT_USER()
+    );
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'SAVED',
+        'config_id', config_id,
+        'config_name', name,
+        'use_case', config:meta_requirements:use_case_name::VARCHAR,
+        'next_steps', ARRAY_CONSTRUCT(
+            '1. Review: SELECT CONFIG FROM META_RECO_CONFIGS WHERE CONFIG_ID = ''' || config_id || '''',
+            '2. Edit if needed: CALL update_reco_config(''' || config_id || ''', <updated_config>)',
+            '3. Approve: CALL approve_reco_config(''' || config_id || ''', ''<approval_notes>'')',
+            '4. Deploy: CALL deploy_reco_config(''' || config_id || ''')'
+        )
+    );
+END;
+$$;
+
+-- =============================================================================
+-- PROCEDURE: Update config (only if PENDING_REVIEW)
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE update_reco_config(
+    config_id VARCHAR,
+    updated_config VARIANT
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    current_status VARCHAR;
+BEGIN
+    SELECT STATUS INTO current_status
+    FROM META_RECO_CONFIGS
+    WHERE CONFIG_ID = :config_id;
+    
+    IF (current_status IS NULL) THEN
+        RETURN OBJECT_CONSTRUCT(
+            'status', 'ERROR',
+            'message', 'Config not found: ' || config_id
+        );
+    END IF;
+    
+    IF (current_status != 'PENDING_REVIEW') THEN
+        RETURN OBJECT_CONSTRUCT(
+            'status', 'ERROR',
+            'message', 'Config can only be updated when status is PENDING_REVIEW. Current status: ' || current_status
+        );
+    END IF;
+    
+    UPDATE META_RECO_CONFIGS
+    SET CONFIG = :updated_config,
+        REVIEWED_AT = CURRENT_TIMESTAMP(),
+        REVIEWED_BY = CURRENT_USER()
+    WHERE CONFIG_ID = :config_id;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'UPDATED',
+        'config_id', config_id,
+        'reviewed_by', CURRENT_USER(),
+        'message', 'Config updated. Ready for approval.'
+    );
+END;
+$$;
+
+-- =============================================================================
+-- PROCEDURE: Human approval step (REQUIRED before deployment)
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE approve_reco_config(
+    config_id VARCHAR,
+    approval_notes VARCHAR DEFAULT NULL
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    current_status VARCHAR;
+    config_name VARCHAR;
+BEGIN
+    SELECT STATUS, CONFIG_NAME INTO current_status, config_name
+    FROM META_RECO_CONFIGS
+    WHERE CONFIG_ID = :config_id;
+    
+    IF (current_status IS NULL) THEN
+        RETURN OBJECT_CONSTRUCT(
+            'status', 'ERROR',
+            'message', 'Config not found: ' || config_id
+        );
+    END IF;
+    
+    IF (current_status NOT IN ('PENDING_REVIEW')) THEN
+        RETURN OBJECT_CONSTRUCT(
+            'status', 'ERROR',
+            'message', 'Config can only be approved when status is PENDING_REVIEW. Current status: ' || current_status
+        );
+    END IF;
+    
+    UPDATE META_RECO_CONFIGS
+    SET STATUS = 'APPROVED',
+        APPROVED_AT = CURRENT_TIMESTAMP(),
+        APPROVED_BY = CURRENT_USER(),
+        APPROVAL_NOTES = :approval_notes
+    WHERE CONFIG_ID = :config_id;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'APPROVED',
+        'config_id', config_id,
+        'config_name', config_name,
+        'approved_by', CURRENT_USER(),
+        'approved_at', CURRENT_TIMESTAMP(),
+        'message', 'Config approved and ready for deployment.',
+        'next_step', 'CALL deploy_reco_config(''' || config_id || ''')'
+    );
+END;
+$$;
+
+-- =============================================================================
+-- PROCEDURE: Deploy ONLY if APPROVED (creates objects with RECO_ prefix)
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE deploy_reco_config(config_id VARCHAR)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    config VARIANT;
+    current_status VARCHAR;
+    use_case_ref VARCHAR;
+    pipe_name VARCHAR;
+    stream_name VARCHAR;
+    task_name VARCHAR;
+    view_name VARCHAR;
+    source_path VARCHAR;
+BEGIN
+    SELECT c.CONFIG, c.STATUS, c.USE_CASE_REF 
+    INTO config, current_status, use_case_ref
+    FROM META_RECO_CONFIGS c
+    WHERE c.CONFIG_ID = :config_id;
+    
+    IF (config IS NULL) THEN
+        RETURN OBJECT_CONSTRUCT(
+            'status', 'ERROR',
+            'message', 'Config not found: ' || config_id
+        );
+    END IF;
+    
+    IF (current_status != 'APPROVED') THEN
+        RETURN OBJECT_CONSTRUCT(
+            'status', 'ERROR',
+            'message', 'Config must be APPROVED before deployment. Current status: ' || current_status,
+            'action', 'CALL approve_reco_config(''' || config_id || ''') first'
+        );
+    END IF;
+    
+    pipe_name := config:pipeline_settings:pipeline_name::VARCHAR;
+    stream_name := pipe_name || '_STREAM';
+    task_name := pipe_name || '_TASK';
+    view_name := pipe_name || '_VIEW';
+    source_path := config:source:full_path::VARCHAR;
+    
+    EXECUTE IMMEDIATE 'CREATE OR REPLACE STREAM META_CAPI_DB.PIPELINE.' || stream_name || 
+        ' ON TABLE ' || source_path || ' APPEND_ONLY = TRUE';
+    
+    -- Build USER_DATA and CUSTOM_DATA from column_mappings
+    LET user_data_parts VARCHAR := '';
+    LET custom_data_parts VARCHAR := '';
+    LET event_id_expr VARCHAR := '''evt_'' || UUID_STRING()';
+    LET event_time_expr VARCHAR := 'CURRENT_TIMESTAMP()';
+    LET event_source_url_expr VARCHAR := 'NULL';
+    
+    FOR mapping IN (SELECT VALUE FROM TABLE(FLATTEN(input => config:column_mappings)) WHERE VALUE:include::BOOLEAN = TRUE) DO
+        LET target VARCHAR := mapping:target_column::VARCHAR;
+        LET source VARCHAR := mapping:source_column::VARCHAR;
+        LET hashed BOOLEAN := mapping:requires_hashing::BOOLEAN;
+        LET col_expr VARCHAR;
+        
+        IF (target IS NULL) THEN CONTINUE; END IF;
+        IF (target = 'EVENT_ID') THEN event_id_expr := 'COALESCE(' || source || '::VARCHAR, ''evt_'' || UUID_STRING())'; CONTINUE; END IF;
+        IF (target = 'EVENT_TIME') THEN event_time_expr := source || '::TIMESTAMP_NTZ'; CONTINUE; END IF;
+        IF (target = 'EVENT_SOURCE_URL') THEN event_source_url_expr := source; CONTINUE; END IF;
+        
+        IF (hashed) THEN col_expr := 'ARRAY_CONSTRUCT(SHA2(LOWER(TRIM(' || source || ')), 256))';
+        ELSE col_expr := source; END IF;
+        
+        IF (target IN ('EM', 'PH', 'FN', 'LN', 'GE', 'DB', 'CT', 'ST', 'ZP', 'COUNTRY', 'EXTERNAL_ID', 'CLIENT_IP_ADDRESS', 'CLIENT_USER_AGENT', 'FBC', 'FBP')) THEN
+            user_data_parts := user_data_parts || '''' || LOWER(target) || ''', ' || col_expr || ', ';
+        ELSE
+            custom_data_parts := custom_data_parts || '''' || LOWER(target) || ''', ' || col_expr || ', ';
+        END IF;
+    END FOR;
+    
+    user_data_parts := RTRIM(user_data_parts, ', ');
+    custom_data_parts := RTRIM(custom_data_parts, ', ');
+    LET user_data_sql VARCHAR := CASE WHEN user_data_parts = '' THEN 'NULL' ELSE 'OBJECT_CONSTRUCT_KEEP_NULL(' || user_data_parts || ')' END;
+    LET custom_data_sql VARCHAR := CASE WHEN custom_data_parts = '' THEN 'NULL' ELSE 'OBJECT_CONSTRUCT_KEEP_NULL(' || custom_data_parts || ')' END;
+    
+    EXECUTE IMMEDIATE '
+    CREATE OR REPLACE VIEW META_CAPI_DB.PIPELINE.' || view_name || ' AS
+    SELECT 
+        ' || event_id_expr || ' AS EVENT_ID,
+        ''' || config:event_settings:event_type::VARCHAR || ''' AS EVENT_NAME,
+        ' || event_time_expr || ' AS EVENT_TIME,
+        ''' || config:event_settings:action_source::VARCHAR || ''' AS ACTION_SOURCE,
+        ' || event_source_url_expr || ' AS EVENT_SOURCE_URL,
+        ' || user_data_sql || ' AS USER_DATA,
+        ' || custom_data_sql || ' AS CUSTOM_DATA
+    FROM META_CAPI_DB.PIPELINE.' || stream_name;
+    
+    EXECUTE IMMEDIATE '
+    CREATE OR REPLACE TASK META_CAPI_DB.PIPELINE.' || task_name || '
+        WAREHOUSE = COMPUTE_WH
+        SCHEDULE = ''60 MINUTE''
+        WHEN SYSTEM$STREAM_HAS_DATA(''META_CAPI_DB.PIPELINE.' || stream_name || ''')
+    AS
+        INSERT INTO META_CAPI_DB.PIPELINE.META_CAPI_EVENTS 
+        (EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, EVENT_SOURCE_URL, USER_DATA, CUSTOM_DATA, STATUS, CREATED_AT)
+        SELECT EVENT_ID, EVENT_NAME, EVENT_TIME, ACTION_SOURCE, EVENT_SOURCE_URL, USER_DATA, CUSTOM_DATA, ''PENDING'', CURRENT_TIMESTAMP()
+        FROM META_CAPI_DB.PIPELINE.' || view_name;
+    
+    UPDATE META_RECO_CONFIGS
+    SET STATUS = 'DEPLOYED',
+        DEPLOYED_AT = CURRENT_TIMESTAMP(),
+        DEPLOYED_BY = CURRENT_USER(),
+        DEPLOYED_OBJECTS = OBJECT_CONSTRUCT(
+            'stream', stream_name,
+            'view', view_name,
+            'task', task_name
+        )
+    WHERE CONFIG_ID = :config_id;
+    
+    CALL mark_recommendation_implemented(:use_case_ref);
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'DEPLOYED',
+        'config_id', config_id,
+        'pipeline_name', pipe_name,
+        'deployed_by', CURRENT_USER(),
+        'deployed_at', CURRENT_TIMESTAMP(),
+        'objects_created', OBJECT_CONSTRUCT(
+            'stream', 'META_CAPI_DB.PIPELINE.' || stream_name,
+            'view', 'META_CAPI_DB.PIPELINE.' || view_name,
+            'task', 'META_CAPI_DB.PIPELINE.' || task_name
+        ),
+        'recommendation_status', 'IMPLEMENTED',
+        'next_step', 'Run ALTER TASK META_CAPI_DB.PIPELINE.' || task_name || ' RESUME to activate'
+    );
+END;
+$$;
+
+-- =============================================================================
+-- PROCEDURE: List all recommendation configs
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE list_reco_configs()
+RETURNS TABLE (
+    config_id VARCHAR,
+    config_name VARCHAR,
+    use_case_name VARCHAR,
+    source_table VARCHAR,
+    status VARCHAR,
+    created_by VARCHAR,
+    created_at TIMESTAMP_NTZ,
+    approved_by VARCHAR,
+    deployed_at TIMESTAMP_NTZ
+)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+BEGIN
+    res := (
+        SELECT 
+            CONFIG_ID,
+            CONFIG_NAME,
+            USE_CASE_NAME,
+            SOURCE_DATABASE || '.' || SOURCE_SCHEMA || '.' || SOURCE_TABLE AS SOURCE_TABLE,
+            STATUS,
+            CREATED_BY,
+            CREATED_AT,
+            APPROVED_BY,
+            DEPLOYED_AT
+        FROM META_RECO_CONFIGS
+        ORDER BY CREATED_AT DESC
+    );
+    RETURN TABLE(res);
+END;
+$$;
+
+-- =============================================================================
+-- VIEW: Summary of recommendation configs
+-- =============================================================================
+CREATE OR REPLACE VIEW V_RECO_CONFIG_STATUS AS
+SELECT 
+    CONFIG_NAME,
+    USE_CASE_NAME,
+    SOURCE_DATABASE || '.' || SOURCE_SCHEMA || '.' || SOURCE_TABLE AS SOURCE_TABLE,
+    STATUS,
+    CREATED_BY,
+    CREATED_AT,
+    APPROVED_BY,
+    APPROVED_AT,
+    DEPLOYED_BY,
+    DEPLOYED_AT
+FROM META_RECO_CONFIGS
+ORDER BY 
+    CASE STATUS 
+        WHEN 'PENDING_REVIEW' THEN 1 
+        WHEN 'APPROVED' THEN 2 
+        WHEN 'DEPLOYED' THEN 3 
+    END,
+    CREATED_AT DESC;

--- a/samples/meta-capi-pipeline/sql/05_recommendations/recommendations.sql
+++ b/samples/meta-capi-pipeline/sql/05_recommendations/recommendations.sql
@@ -1,0 +1,261 @@
+-- =============================================================================
+-- META USE CASE RECOMMENDATIONS - API Integration
+-- Fetches recommendations from Meta's Use Case Recommendation API
+-- =============================================================================
+
+USE SCHEMA META_CAPI_DB.PIPELINE;
+
+-- =============================================================================
+-- TABLE: Store recommendations from Meta
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS META_CAPI_RECOMMENDATIONS (
+    RECOMMENDATION_ID VARCHAR(100) DEFAULT UUID_STRING() PRIMARY KEY,
+    AD_ACCOUNT_ID VARCHAR(50),
+    BUSINESS_ID VARCHAR(50),
+    DATA_SOURCE_ID VARCHAR(50),
+    USE_CASE_NAME VARCHAR(200),
+    USE_CASE_REF VARCHAR(100),
+    DESCRIPTION VARCHAR(1000),
+    REQUIRED_EVENTS VARIANT,
+    RECOMMENDED_EVENTS VARIANT,
+    IMPLEMENTATION_STATUS VARCHAR(20) DEFAULT 'NOT_IMPLEMENTED',
+    FETCHED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    IMPLEMENTED_AT TIMESTAMP_NTZ,
+    RAW_RESPONSE VARIANT
+);
+
+-- =============================================================================
+-- PYTHON UDTF: Call Meta Use Case Recommendation API
+-- Endpoint: https://api.facebook.com/signals/use_case_recommendation
+-- =============================================================================
+CREATE OR REPLACE FUNCTION call_meta_recommendation_api(
+    ad_account_id VARCHAR,
+    business_id VARCHAR,
+    data_source_id VARCHAR
+)
+RETURNS TABLE (
+    use_case_name VARCHAR,
+    use_case_ref VARCHAR,
+    description VARCHAR,
+    required_events VARIANT,
+    recommended_events VARIANT,
+    raw_response VARIANT
+)
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.11'
+PACKAGES = ('requests', 'snowflake-snowpark-python')
+HANDLER = 'MetaRecommendationHandler'
+EXTERNAL_ACCESS_INTEGRATIONS = (meta_capi_integration)
+SECRETS = ('access_token' = meta_capi_access_token)
+AS $$
+import _snowflake
+import requests
+import json
+
+class MetaRecommendationHandler:
+    def process(self, ad_account_id, business_id, data_source_id):
+        token = _snowflake.get_generic_secret_string('access_token')
+        
+        params = {}
+        if ad_account_id:
+            params['ad_account_id'] = ad_account_id
+        if business_id:
+            params['business_id'] = business_id
+        if data_source_id:
+            params['data_source_id'] = data_source_id
+        
+        if not params:
+            yield ('ERROR', None, 'At least one of ad_account_id, business_id, or data_source_id is required', None, None, None)
+            return
+        
+        try:
+            response = requests.get(
+                'https://api.facebook.com/signals/use_case_recommendation',
+                params=params,
+                headers={'Authorization': f'Bearer {token}'},
+                timeout=30
+            )
+            response.raise_for_status()
+            data = response.json()
+            
+            recommendations = data.get('data', {}).get('recommendations', [])
+            
+            if not recommendations:
+                yield ('NO_RECOMMENDATIONS', None, 'No recommendations returned from Meta API', None, None, data)
+                return
+            
+            for rec in recommendations:
+                uc = rec.get('use_case', {})
+                yield (
+                    uc.get('name'),
+                    uc.get('ref'),
+                    uc.get('description'),
+                    uc.get('requiredEvents'),
+                    uc.get('recommendedEvents'),
+                    rec
+                )
+        except requests.exceptions.RequestException as e:
+            yield ('ERROR', None, f'API request failed: {str(e)}', None, None, None)
+        except json.JSONDecodeError as e:
+            yield ('ERROR', None, f'Invalid JSON response: {str(e)}', None, None, None)
+$$;
+
+-- =============================================================================
+-- PROCEDURE: Fetch and store recommendations from Meta
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE get_use_case_recommendations(
+    ad_account_id VARCHAR DEFAULT NULL,
+    business_id VARCHAR DEFAULT NULL,
+    data_source_id VARCHAR DEFAULT NULL
+)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    rec_count INTEGER;
+    fetch_time TIMESTAMP_NTZ;
+BEGIN
+    fetch_time := CURRENT_TIMESTAMP();
+    
+    INSERT INTO META_CAPI_RECOMMENDATIONS (
+        RECOMMENDATION_ID,
+        AD_ACCOUNT_ID,
+        BUSINESS_ID,
+        DATA_SOURCE_ID,
+        USE_CASE_NAME,
+        USE_CASE_REF,
+        DESCRIPTION,
+        REQUIRED_EVENTS,
+        RECOMMENDED_EVENTS,
+        IMPLEMENTATION_STATUS,
+        FETCHED_AT,
+        RAW_RESPONSE
+    )
+    SELECT 
+        UUID_STRING(),
+        :ad_account_id,
+        :business_id,
+        :data_source_id,
+        USE_CASE_NAME,
+        USE_CASE_REF,
+        DESCRIPTION,
+        REQUIRED_EVENTS,
+        RECOMMENDED_EVENTS,
+        'NOT_IMPLEMENTED',
+        :fetch_time,
+        RAW_RESPONSE
+    FROM TABLE(call_meta_recommendation_api(:ad_account_id, :business_id, :data_source_id))
+    WHERE USE_CASE_REF IS NOT NULL;
+    
+    SELECT COUNT(*) INTO rec_count 
+    FROM META_CAPI_RECOMMENDATIONS 
+    WHERE FETCHED_AT = :fetch_time;
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', CASE WHEN rec_count > 0 THEN 'SUCCESS' ELSE 'NO_RECOMMENDATIONS' END,
+        'recommendations_fetched', rec_count,
+        'ad_account_id', ad_account_id,
+        'business_id', business_id,
+        'data_source_id', data_source_id,
+        'fetched_at', fetch_time,
+        'next_step', 'CALL discover_tables_for_recommendations() to find matching tables'
+    );
+END;
+$$;
+
+-- =============================================================================
+-- VIEW: Pending recommendations (not yet implemented)
+-- =============================================================================
+CREATE OR REPLACE VIEW V_PENDING_RECOMMENDATIONS AS
+SELECT 
+    RECOMMENDATION_ID,
+    USE_CASE_NAME,
+    USE_CASE_REF,
+    DESCRIPTION,
+    REQUIRED_EVENTS:events[0]::VARCHAR AS PRIMARY_EVENT_TYPE,
+    REQUIRED_EVENTS:parameters AS REQUIRED_PARAMETERS,
+    RECOMMENDED_EVENTS,
+    FETCHED_AT
+FROM META_CAPI_RECOMMENDATIONS 
+WHERE IMPLEMENTATION_STATUS = 'NOT_IMPLEMENTED'
+AND FETCHED_AT = (
+    SELECT MAX(FETCHED_AT) FROM META_CAPI_RECOMMENDATIONS
+);
+
+-- =============================================================================
+-- VIEW: All recommendations with status
+-- =============================================================================
+CREATE OR REPLACE VIEW V_RECOMMENDATIONS_STATUS AS
+SELECT 
+    USE_CASE_NAME,
+    USE_CASE_REF,
+    DESCRIPTION,
+    REQUIRED_EVENTS:events[0]::VARCHAR AS EVENT_TYPE,
+    ARRAY_SIZE(REQUIRED_EVENTS:parameters::ARRAY) AS REQUIRED_PARAM_COUNT,
+    IMPLEMENTATION_STATUS,
+    FETCHED_AT,
+    IMPLEMENTED_AT
+FROM META_CAPI_RECOMMENDATIONS
+ORDER BY FETCHED_AT DESC, USE_CASE_NAME;
+
+-- =============================================================================
+-- PROCEDURE: List recommendations with detailed information
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE list_recommendations()
+RETURNS TABLE (
+    use_case_name VARCHAR,
+    use_case_ref VARCHAR,
+    event_type VARCHAR,
+    required_parameters VARCHAR,
+    description VARCHAR,
+    status VARCHAR,
+    fetched_at TIMESTAMP_NTZ
+)
+LANGUAGE SQL
+AS
+$$
+DECLARE
+    res RESULTSET;
+BEGIN
+    res := (
+        SELECT 
+            USE_CASE_NAME,
+            USE_CASE_REF,
+            REQUIRED_EVENTS:events[0]::VARCHAR AS EVENT_TYPE,
+            (SELECT LISTAGG(p.value:key::VARCHAR, ', ') 
+             FROM TABLE(FLATTEN(REQUIRED_EVENTS:parameters)) p) AS REQUIRED_PARAMETERS,
+            DESCRIPTION,
+            IMPLEMENTATION_STATUS AS STATUS,
+            FETCHED_AT
+        FROM META_CAPI_RECOMMENDATIONS
+        WHERE FETCHED_AT = (SELECT MAX(FETCHED_AT) FROM META_CAPI_RECOMMENDATIONS)
+        ORDER BY USE_CASE_NAME
+    );
+    RETURN TABLE(res);
+END;
+$$;
+
+-- =============================================================================
+-- PROCEDURE: Mark recommendation as implemented
+-- Called internally by deploy_reco_config
+-- =============================================================================
+CREATE OR REPLACE PROCEDURE mark_recommendation_implemented(use_case_ref VARCHAR)
+RETURNS VARIANT
+LANGUAGE SQL
+AS
+$$
+BEGIN
+    UPDATE META_CAPI_RECOMMENDATIONS
+    SET IMPLEMENTATION_STATUS = 'IMPLEMENTED',
+        IMPLEMENTED_AT = CURRENT_TIMESTAMP()
+    WHERE USE_CASE_REF = :use_case_ref
+    AND IMPLEMENTATION_STATUS = 'NOT_IMPLEMENTED';
+    
+    RETURN OBJECT_CONSTRUCT(
+        'status', 'UPDATED',
+        'use_case_ref', use_case_ref,
+        'implemented_at', CURRENT_TIMESTAMP()
+    );
+END;
+$$;


### PR DESCRIPTION
## Summary

- Adds a Cortex Code skill that builds and manages Meta Conversions API (CAPI) pipelines entirely within Snowflake
- Enables server-side event streaming (purchases, leads, etc.) from Snowflake tables to Meta's Graph API for ad attribution
- Includes auto-discovery of compatible tables, CDC pipeline generation, PII hashing, monitoring, and Meta AI recommendations

## What's Included

- `SKILL.md` — Main skill definition with intent routing and workflow
- `sql/` — All SQL scripts organized by stage (discovery, setup, processing, monitoring, troubleshooting, recommendations)
- `references/meta_events.md` — Meta standard events reference
- `README.md` — Installation, usage, prerequisites, and architecture
- `LICENSE` — Snowflake Skills License

## Test plan

- [ ] Install skill in Cortex Code and verify trigger phrases activate correctly
- [ ] Run discovery flow against a test table with email/phone/value columns
- [ ] Verify pipeline deployment creates stream, view, and task
- [ ] Confirm PII fields are SHA256-hashed in the mapping view
- [ ] Test event processing via the Python UDTF against Meta's test endpoint

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)