### PR TITLE
Fix meta-capi-pipeline README repo URLs and license

### DIFF
--- a/samples/meta-capi-pipeline/README.md
+++ b/samples/meta-capi-pipeline/README.md
@@ -15,17 +15,17 @@ A Cortex Code skill that builds and manages Meta Conversions API (CAPI) pipeline
 
 This skill lives in [Snowflake-Labs/sf-samples](https://github.com/Snowflake-Labs/sf-samples/tree/main/samples/meta-capi-pipeline).
 
-### Option 1: Clone and symlink
+### Recommended: install from Cortex Code
 
-```bash
-# Clone the sf-samples repo anywhere
-git clone https://github.com/Snowflake-Labs/sf-samples.git
+Run this in a Cortex Code session to download and install the skill in one step:
 
-# Symlink the skill into your Cortex Code skills directory
-ln -s "$(pwd)/sf-samples/samples/meta-capi-pipeline" ~/.snowflake/cortex/skills/meta-capi-pipeline
+```
+/skill add https://github.com/Snowflake-Labs/sf-samples.git/samples/meta-capi-pipeline
 ```
 
-### Option 2: Sparse checkout (skill only)
+### Manual (for development)
+
+Clone the repo and symlink the skill into your Cortex Code skills directory:
 
 ```bash
 git clone --depth 1 --filter=blob:none --sparse https://github.com/Snowflake-Labs/sf-samples.git
@@ -34,14 +34,9 @@ git sparse-checkout set samples/meta-capi-pipeline
 ln -s "$(pwd)/samples/meta-capi-pipeline" ~/.snowflake/cortex/skills/meta-capi-pipeline
 ```
 
-### Verify Installation
+### Verify installation
 
-In Cortex Code, run:
-```
-/skills
-```
-
-You should see `meta-capi-pipeline` listed.
+In Cortex Code, run `/skill` and confirm `meta-capi-pipeline` is listed.
 
 ## Usage
 

--- a/samples/meta-capi-pipeline/README.md
+++ b/samples/meta-capi-pipeline/README.md
@@ -13,24 +13,25 @@ A Cortex Code skill that builds and manages Meta Conversions API (CAPI) pipeline
 
 ## Installation
 
-### Option 1: Clone to Skills Directory
+This skill lives in [Snowflake-Labs/sf-samples](https://github.com/Snowflake-Labs/sf-samples/tree/main/samples/meta-capi-pipeline).
+
+### Option 1: Clone and symlink
 
 ```bash
-# Navigate to Cortex Code skills directory
-cd ~/.snowflake/cortex/skills
+# Clone the sf-samples repo anywhere
+git clone https://github.com/Snowflake-Labs/sf-samples.git
 
-# Clone this repo
-git clone https://github.com/sfc-gh-vakumar/meta-enhanced-capi.git
+# Symlink the skill into your Cortex Code skills directory
+ln -s "$(pwd)/sf-samples/samples/meta-capi-pipeline" ~/.snowflake/cortex/skills/meta-capi-pipeline
 ```
 
-### Option 2: Symlink (for development)
+### Option 2: Sparse checkout (skill only)
 
 ```bash
-# Clone anywhere
-git clone https://github.com/sfc-gh-vakumar/meta-enhanced-capi.git ~/projects/meta-enhanced-capi
-
-# Symlink to skills directory
-ln -s ~/projects/meta-enhanced-capi ~/.snowflake/cortex/skills/meta-enhanced-capi
+git clone --depth 1 --filter=blob:none --sparse https://github.com/Snowflake-Labs/sf-samples.git
+cd sf-samples
+git sparse-checkout set samples/meta-capi-pipeline
+ln -s "$(pwd)/samples/meta-capi-pipeline" ~/.snowflake/cortex/skills/meta-capi-pipeline
 ```
 
 ### Verify Installation
@@ -40,7 +41,7 @@ In Cortex Code, run:
 /skills
 ```
 
-You should see `meta-enhanced-capi` listed.
+You should see `meta-capi-pipeline` listed.
 
 ## Usage
 
@@ -81,7 +82,7 @@ Before using this skill, ensure you have:
 ## Skill Structure
 
 ```
-meta-enhanced-capi/
+meta-capi-pipeline/
 ├── SKILL.md                 # Main skill definition
 ├── README.md                # This file
 ├── references/
@@ -107,4 +108,4 @@ meta-enhanced-capi/
 
 ## License
 
-MIT
+Snowflake Skills License. See the [LICENSE](./LICENSE) file for details.


### PR DESCRIPTION
## Summary

Follow-up to #283. Corrects the `samples/meta-capi-pipeline/README.md`:

- **Install URLs** now point to `Snowflake-Labs/sf-samples` (the skill's actual home at `samples/meta-capi-pipeline`) instead of a personal fork (`sfc-gh-vakumar/meta-enhanced-capi`). Adds a clone+symlink option and a sparse-checkout option.
- **Folder-name references** updated to `meta-capi-pipeline` (verify text and structure diagram).
- **License** corrected from `MIT` to **Snowflake Skills License**, matching the `LICENSE` file already shipped in the skill folder.

No functional/skill changes — README only.

## Test plan
- [ ] Confirm no `sfc-gh-vakumar` or `meta-enhanced-capi` references remain in the README
- [ ] Confirm the stated license matches `samples/meta-capi-pipeline/LICENSE`

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)