### PR TITLE
Add boxoffice-signal-ml-starter: predicting outcomes from public conversation with Cortex AISQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If it doesn't fit neatly into one of those — or crosses multiple areas — thi
 | [leveraging_kumo_for_smarter_recommendations](samples/leveraging_kumo_for_smarter_recommendations) | Product recommendations for high-LTV customers using Kumo's Native App |
 | [prescriptive-maintenance-demo](samples/prescriptive-maintenance-demo) | Prescriptive maintenance with scikit-learn and Snowpark |
 | [multimodal-process-analytics](samples/multimodal-process-analytics) | Multimodal process analytics notebook using ML |
+| [boxoffice-signal-ml-starter](samples/boxoffice-signal-ml-starter) | Predicting outcomes from public conversation: Cortex AISQL intent scoring, as-of feature engineering, walk-forward validation |
 
 ### Snowpark
 

--- a/samples/boxoffice-signal-ml-starter/.env.example
+++ b/samples/boxoffice-signal-ml-starter/.env.example
@@ -1,0 +1,35 @@
+# Copy to .env and fill in YOUR OWN values. .env is git-ignored. Never commit real keys.
+# The names below are source-agnostic so they fit whichever provider you choose. Once CoCo
+# helps you research each source (see docs/03), you'll know which provider issues each key.
+
+# --- Search-interest signal (Source A) ---
+# Key for the entity/topic lookup service used to resolve a film title to a stable ID
+# (so your search-interest pulls track the film, not unrelated same-name searches).
+SEARCH_ENTITY_API_KEY=
+
+# Some search-interest libraries need no key but do need a session/locale config.
+SEARCH_INTEREST_LOCALE=en-US
+SEARCH_INTEREST_TZ=360
+
+# --- Trailer-comment signal (Source B) ---
+# If you use an official platform API for comments, put its key here.
+# (The dossier also describes a no-API path; prefer official access where available.)
+COMMENT_PLATFORM_API_KEY=
+
+# --- Consumer research pageview signal (Source C) ---
+# Typically no key required; set a descriptive contact string per the provider's etiquette.
+PAGEVIEW_CONTACT=you@example.com
+
+# --- Box-office history (Source D) ---
+# This provider restricts scraping. Use official/licensed access and place credentials here.
+BOXOFFICE_ACCESS_TOKEN=
+
+# --- Metadata popularity (Source E, optional; excluded from the model as leakage) ---
+METADATA_API_KEY=
+
+# --- Snowflake ---
+# Prefer configuring a named connection with `snow connection add` (see docs/01).
+# These are only used if a script reads them directly.
+SNOWFLAKE_CONNECTION_NAME=my_sandbox
+SANDBOX_DB=MY_SANDBOX_DB
+SANDBOX_SCHEMA=RESEARCH

--- a/samples/boxoffice-signal-ml-starter/COCO.md
+++ b/samples/boxoffice-signal-ml-starter/COCO.md
@@ -1,0 +1,77 @@
+# CoCo context for this sample
+
+You are helping someone reproduce an applied research pipeline: predicting a film's
+opening weekend from the **organic conversation and demand around its trailer**, rather
+than from gameable marketing metrics. The work runs inside Snowflake and is built and
+maintained through Cortex Code.
+
+## Your job when this sample is open
+
+Act as the user's setup guide. Take them, in order, through:
+1. Installing/connecting Cortex Code to their Snowflake account (`docs/01`).
+2. Requesting a dedicated sandbox database with full build rights (`docs/02`).
+3. **Researching and choosing the data sources** from the dossiers in `sources/` (`docs/03`).
+4. Standing up the schema and ingestion for each signal (`docs/04`, `sql/`, `skills/`).
+5. Obtaining and safely storing API keys (`docs/05`).
+
+Before any of that, if they want to see something work immediately, run
+`python model/train_ow_model.py --sample` — synthetic data, no Snowflake needed, proves the
+modeling side is healthy in about ten minutes.
+
+## Rigor you are responsible for enforcing
+
+The user will be tempted to skip these. Don't let them, and say why:
+
+- **As-of discipline.** Every feature at a −N-day horizon must use only data available on that
+  day. `sql/05_demand_percentiles.sql` and `sql/10_feature_view.sql` enforce it; `sql/10` ends
+  with three tripwires. If comment volume is flat across horizons, it is broken.
+- **A surprising aggregate deserves a check, not a celebration or an accusation.** MAPE is a mean
+  over the whole film set; individual films landing almost exactly right is normal and is not a
+  symptom of anything. But if the aggregate comes in well below the reference build (~38% on 122
+  films), or jumps sharply after a feature-pipeline change rather than a model change, walk the
+  leakage checklist before treating it as a gain. Do not tell the user their number is wrong —
+  tell them what to check.
+- **Measure the intent classifier.** `sql/30_intent_eval.sql` needs 150–300 hand labels and
+  returns macro-F1. Without it, every downstream accuracy number has an unmeasured error bar.
+  Watch PASS precision — it is the class that fails quietly and it is half of net intent.
+- **Exclusions are a modeling decision.** Comments are disabled on many family/animated
+  trailers; exclude on the absence of comments, never on the genre flag. Every
+  `REMOVE_FROM_MODEL` row needs a reason.
+- **Missing is not zero.** These features are percentiles; zero-filling a failed pull tells the
+  model the film was the least-demanded in the set.
+
+## Help the user research and choose each data source
+
+The files in `sources/` describe each signal by its characteristics — how it behaves, how
+it's accessed, its quirks, and the schema columns it feeds — rather than prescribing one
+provider, because teams differ in access, budget, and terms. When the user asks "which
+source fits this signal?", use those characteristics plus your own knowledge to suggest the
+most likely public option(s), the access method, and the client library, then help them
+evaluate and set up the one that fits — against their own credentials and each provider's
+terms of service.
+
+There are five signals:
+- **Source A** — a normalized search-interest index; needs a stable id per title and
+  potentially an anchor-term normalization to build a continuous baseline. Read its "known
+  failure modes" section before recommending a client library — the obvious free one is
+  currently broken, and the provider's docs will not tell you that. Check issue trackers.
+- **Source B** — public trailer-comment threads, scored with Snowflake Cortex AISQL into
+  sentiment and intent (theatrical / streaming / pass). Must carry `COMMENT_DATE`.
+- **Source C** — an open entity-id based pageview data source, turned into demand percentiles.
+- **Source D** — an industry box-office tracker (historical grosses + opening weekends).
+- **Source E** — a movie-metadata source; static fields only, live popularity score is leakage.
+
+## Hard rules (do not violate)
+
+- Never write real API keys, tokens, account locators, or personal emails into repo files.
+  Keys live in a git-ignored `.env` (template: `.env.example`).
+- Respect each source's ToS, robots.txt, and rate limits. 
+- Keep internal/customer-specific identifiers out of anything you generate. Use the
+  templated names: `{{SANDBOX_DB}}.{{SCHEMA}}.<TABLE>`.
+
+## Table naming convention (source-agnostic)
+
+`MOVIE_MAP`, `RELEASE_DATES`, `BOX_OFFICE`, `TRAILER_COMMENTS_RAW`,
+`TRAILER_COMMENTS_SCORED`, `SEARCH_INTEREST`, `SEARCH_ANCHOR_BASELINE`, `ENTITY_IDS`,
+`PAGEVIEW_DEMAND`, `MOVIE_METADATA`, `INTENT_GOLD`, `REMOVE_FROM_MODEL`,
+`DEMAND_PERCENTILES` (view, from `sql/05`), `OW_FEATURES` (view, from `sql/10`).

--- a/samples/boxoffice-signal-ml-starter/README.md
+++ b/samples/boxoffice-signal-ml-starter/README.md
@@ -1,0 +1,98 @@
+# Box-Office Signal ML Starter
+
+A hands-on starter kit for reproducing a piece of applied research: **can the organic conversation around a movie trailer predict its opening weekend as well as industry trade data?**
+
+This sample helps you stand up the *pipeline* yourself, inside your own Snowflake account, guided end-to-end by **Cortex Code (CoCo)** — Snowflake's agentic desktop IDE. It is a method kit, not a dataset: you bring your own data access, and the sample brings the schema, the AI scoring, the guardrails, the leakage tripwires, and a set of CoCo prompts that walk you from an empty sandbox to a research-ready feature set.
+
+The techniques generalize past films. Anywhere you have public conversation ahead of a commercial outcome — game launches, product releases, ticketed events — the same pattern applies: classify intent inside the text with Cortex AISQL, build as-of features by horizon, and validate walk-forward in time.
+
+## What it does
+
+- Creates a **source-agnostic schema** for titles, releases, outcomes, trailer comments, search interest, and pageview demand.
+- Scores raw comment text into **sentiment + viewing intent** (theatrical / streaming / pass) with **Snowflake Cortex AISQL** in a single consolidated call.
+- Builds **as-of demand percentiles** at −21 / −14 / −7 / −3 day horizons, so no feature can see past its own prediction date.
+- Assembles an **as-of feature view** (one row per title per horizon) with demand-gated pedigree interactions and no leakage features.
+- Trains a **distributional regressor** (CatBoost + ElasticNet blend, residual-mixture prediction intervals, calibrated demand-forward flag) under **strict walk-forward validation**.
+- Ships an **evaluation harness for the AI classifier itself** — macro-F1 and a per-class confusion matrix — because the intent classification *is* the method.
+
+## Prerequisites
+
+- **Snowflake account** with access to **Cortex AISQL** functions (`AI_SENTIMENT`, `SNOWFLAKE.CORTEX.TRY_COMPLETE`) and a warehouse you can use. An XS is plenty.
+- A **sandbox database** you own, with rights to create schemas, tables, views, and functions inside it. `docs/02_request_a_sandbox.md` has a copy-paste request for your platform team.
+- **Cortex Code (CoCo) Desktop**, connected to that account. See `docs/01_install_cortex_code.md`.
+- **Python 3.9+** for the model (`pip install -r model/requirements.txt`).
+- **Your own access to five public data sources.** None are included or endorsed here — `docs/03_identify_your_sources.md` walks you through choosing them with CoCo, and you are responsible for each provider's terms of service.
+
+## How to run it
+
+### 1. Verify your setup in ten minutes, before wiring up any data
+
+Standing up five data sources takes real time. Don't spend it wondering whether your environment works. The model runs on synthetic data with no Snowflake connection at all:
+
+```bash
+pip install -r model/requirements.txt
+python model/train_ow_model.py --sample
+```
+
+You should see a metric block print with MAPE around 40%. Those numbers describe a random-number generator, not films — don't quote them — but if that runs, the modeling machinery is fine and every later problem is a data problem.
+
+### 2. Then follow the guided path
+
+Open this directory in Cortex Code. `COCO.md` is loaded automatically and primes the agent to act as your setup guide.
+
+| Step | Read | What happens |
+|---|---|---|
+| 1 | `docs/01_install_cortex_code.md` | Install CoCo Desktop, connect it to Snowflake |
+| 2 | `docs/02_request_a_sandbox.md` | Get a sandbox database with full build rights |
+| 3 | `docs/03_identify_your_sources.md` | Research and choose each data source with CoCo |
+| 4 | `docs/04_stand_up_the_pipeline.md` | Create the schema, ingest and score each signal |
+| 5 | `docs/05_api_keys_with_coco.md` | Obtain and store keys safely (never in the repo) |
+| 6 | `docs/06_model_overview.md` | The method, what "good" looks like, and the traps |
+| 7 | `docs/07_model_architecture.md` | The full model framework, with a runnable implementation |
+
+SQL runs in this order:
+
+```bash
+snow sql -f sql/00_schema.sql              # schema (replace {{SANDBOX_DB}})
+snow sql -f sql/20_intent_scoring_aisql.sql # Cortex AISQL sentiment + intent
+snow sql -f sql/30_intent_eval.sql          # macro-F1 for your classifier
+snow sql -f sql/05_demand_percentiles.sql   # as-of demand percentiles by horizon
+snow sql -f sql/10_feature_view.sql         # modeling matrix + leakage tripwires
+python model/train_ow_model.py --connection my_sandbox --database MY_SANDBOX_DB
+```
+
+## What's in here
+
+```
+COCO.md                          agent priming — read automatically by CoCo
+docs/01..07                      the guided path, in order
+sources/source_A..E              signal dossiers: characteristics, gotchas, known failure modes
+skills/                          five installable CoCo skills (ingest, normalize, score, refresh)
+prompts/coco_prompt_library.md   copy-paste CoCo prompts
+sql/00_schema.sql                source-agnostic schema (run first)
+sql/05_demand_percentiles.sql    as-of demand percentiles by horizon  <- the core transform
+sql/10_feature_view.sql          the modeling matrix + leakage tripwires
+sql/20_intent_scoring_aisql.sql  Cortex AISQL sentiment + intent scoring
+sql/30_intent_eval.sql           macro-F1 for your intent classifier   <- don't skip this
+model/train_ow_model.py          runnable reference model (--sample works with no data)
+model/sample_data.py             synthetic feature generator
+.env.example                     key names only; copy to .env, never commit
+```
+
+## Three things this sample insists on
+
+**1. As-of discipline.** Comment threads and search curves keep growing right up to release. Every feature at a −21-day horizon must be computed from data available on that day. `sql/05` and `sql/10` enforce it, and `sql/10` ends with three tripwires that catch it when it breaks.
+
+**2. Check a surprising result before you publish it.** The reference build lands around 38% MAPE on 122 films under strict forward validation. That is a reference point, not a law — a different film set, a longer history, or better features could legitimately do better. But leakage is by far the most common reason an aggregate error lands well below a comparable published baseline, so if yours does, run the checklist before you draw a conclusion from it. Individual predictions are a separate matter: a good model absolutely will nail some films almost exactly, and that is a property of the film, not a symptom.
+
+**3. Measure the AI, not just the model.** Net intent is only as good as the classifier producing it. The reference build's production scorer turned out to sit at macro-F1 0.65 while a revised prompt reached 0.85 on the same hand labels — a gap invisible from output alone. `sql/30_intent_eval.sql` is how you find that out about your own.
+
+## Data, terms, and privacy
+
+**No data is included, and no provider is endorsed.** The `sources/` dossiers describe each signal by its *characteristics* — how it behaves, how it is typically accessed, its known failure modes — and CoCo helps you evaluate the options against your own access and budget. You are responsible for reading each provider's current terms of service and API or scraping policy, and for using official or licensed access where it is offered.
+
+Two rules the sample enforces throughout: keys live in a git-ignored `.env` (template in `.env.example`) and never in a file you commit, and any user handles collected from public comment threads are **pseudonymized on ingest** — hashed, never stored raw.
+
+## License
+
+Apache 2.0, per this repository's [LICENSE](../../LICENSE). **No data is included or licensed** — data access and rights are entirely your responsibility.

--- a/samples/boxoffice-signal-ml-starter/docs/01_install_cortex_code.md
+++ b/samples/boxoffice-signal-ml-starter/docs/01_install_cortex_code.md
@@ -1,0 +1,87 @@
+# 01 — Install Cortex Code and connect it to Snowflake
+
+Cortex Code (CoCo) is Snowflake's agentic desktop IDE. You'll use it to build and run
+everything in this repo through conversation.
+
+## 1. Install Cortex Code Desktop
+
+1. Go to Snowflake's official documentation for Cortex Code and download the desktop app
+   for your OS. https://www.snowflake.com/en/product/snowflake-coco/downloads/
+2. Install and launch it.
+
+> Tip: you can share this github with CoCo once
+> it's running to give it the context of the project.
+
+## 2. Make sure you have the Snowflake CLI
+
+Cortex Code uses named Snowflake connections. The `snow` CLI is the easiest way to create
+and test them.
+
+```bash
+# macOS (Homebrew)
+brew install snowflake-cli
+snow --version
+```
+
+For other platforms, follow the official Snowflake CLI install docs.
+
+## 3. Add a connection to your account
+
+You need: your **account identifier**, your **username**, and an auth method. **Key-pair
+auth is strongly recommended** for agentic use because it doesn't trigger a browser popup
+on every action.
+
+```bash
+snow connection add
+# You'll be prompted for:
+#   Connection name:      my_sandbox
+#   Account:              <your_org>-<your_account>
+#   User:                 <your_username>
+#   Authenticator:        SNOWFLAKE_JWT        (key-pair)  — or  externalbrowser (SSO)
+#   Private key file:     ~/.snowflake/keys/rsa_key.p8     (if using key-pair)
+#   Role / Warehouse / Database / Schema: set to your sandbox once you have it (docs/02)
+```
+
+### Generating a key pair (if needed for your organizations login practices if you don't have one)
+
+```bash
+# private key (encrypted) + public key
+openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 aes-256-cbc -inform PEM -out rsa_key.p8
+openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+```
+
+Give the **public** key to whoever administers your Snowflake user (or set it yourself if
+you can):
+
+```sql
+ALTER USER <your_username> SET RSA_PUBLIC_KEY='<paste the public key body, no header/footer>';
+```
+
+Keep the **private** key local and never commit it (`.gitignore` already blocks `*.p8`).
+
+## 4. Test the connection
+
+```bash
+snow connection test --connection my_sandbox
+snow sql --connection my_sandbox -q "SELECT CURRENT_USER(), CURRENT_ROLE(), CURRENT_ACCOUNT();"
+```
+
+## 5. Point Cortex Code at this folder
+
+Open this repository folder in Cortex Code. It will auto-load `COCO.md`, which primes the
+agent to act as your setup guide. Then open the chat and try:
+
+> "Read COCO.md and docs/02. I don't have a sandbox database yet — help me draft the
+> request to my data team."
+
+## Connection cheatsheet
+
+| Thing | Where it comes from |
+|---|---|
+| Account identifier | Snowsight → account menu, or your admin |
+| Username | Your Snowflake login |
+| Role | Your sandbox role (see `docs/02`) |
+| Warehouse | A small warehouse you're allowed to use (e.g. an XS) |
+| Auth | Key-pair (`SNOWFLAKE_JWT`) recommended; SSO (`externalbrowser`) works too |
+
+Next: **`docs/02_request_a_sandbox.md`**.

--- a/samples/boxoffice-signal-ml-starter/docs/02_request_a_sandbox.md
+++ b/samples/boxoffice-signal-ml-starter/docs/02_request_a_sandbox.md
@@ -1,0 +1,82 @@
+# 02 — Request a dedicated sandbox database
+
+You need a place you **fully control** — where you can create schemas, tables, views,
+stages, and run Cortex AISQL — without touching production or needing a ticket for every
+change. Ask your data/platform team for a dedicated **sandbox database**.
+
+Building in an isolated sandbox (rather than an existing shared database) matters because:
+
+- You'll iterate fast and create/drop objects constantly — that shouldn't risk shared data.
+- Ingested third-party data must stay contained and easy to purge.
+- Clear ownership keeps you compliant: your sandbox, your data-access responsibility.
+
+## What to ask for
+
+- A **database** you own (e.g. `MY_SANDBOX_DB`).
+- A **role** granted to you with **full privileges inside that database** (create schema,
+  table, view, stage, function, task) — scoped to the sandbox only.
+- Rights to use **Snowflake Cortex** functions (AISQL) — e.g. usage on the Cortex
+  functions and a warehouse that permits them.
+- A **warehouse** you may use (an XS/S is plenty to start).
+- Optionally, an **external access integration** if you'll pull APIs from inside Snowflake
+  (many people instead pull locally with CoCo and load results — either is fine).
+
+## Copy-paste request for your data team
+
+> **Subject: Request for a personal sandbox database (analytics research)**
+>
+> Hi team — I'm prototyping a data-science pipeline with Cortex Code and need an isolated
+> place to build. Could you set up the following?
+>
+> 1. A dedicated database, e.g. `MY_SANDBOX_DB`, that I own.
+> 2. A role (e.g. `MY_SANDBOX_ROLE`) granted to my user, with full build privileges
+>    **inside that database only** (create/modify schema, table, view, stage, function,
+>    task).
+> 3. Usage on a warehouse (an XS is fine) and permission to call Snowflake Cortex / AISQL
+>    functions.
+> 4. (Optional) An external access integration if I'll call external APIs from inside
+>    Snowflake — otherwise I'll ingest locally and load results.
+>
+> All data I bring in will be third-party data I ingest under my own access; I'll keep it
+> contained in this database and won't reshare it. Happy to follow any governance you
+> require.
+>
+> Thanks!
+
+## Reference: what the grants roughly look like
+
+Your admin can adapt this. (You typically won't run it yourself — it's here so you can
+speak your team's language.)
+
+```sql
+-- Admin-run, illustrative only
+CREATE DATABASE IF NOT EXISTS MY_SANDBOX_DB;
+CREATE ROLE IF NOT EXISTS MY_SANDBOX_ROLE;
+
+GRANT OWNERSHIP ON DATABASE MY_SANDBOX_DB TO ROLE MY_SANDBOX_ROLE COPY CURRENT GRANTS;
+GRANT USAGE ON WAREHOUSE MY_XS_WH TO ROLE MY_SANDBOX_ROLE;
+
+-- full build rights inside the sandbox
+GRANT ALL ON DATABASE MY_SANDBOX_DB TO ROLE MY_SANDBOX_ROLE;
+GRANT ALL ON ALL SCHEMAS IN DATABASE MY_SANDBOX_DB TO ROLE MY_SANDBOX_ROLE;
+GRANT ALL ON FUTURE SCHEMAS IN DATABASE MY_SANDBOX_DB TO ROLE MY_SANDBOX_ROLE;
+
+-- assign to you
+GRANT ROLE MY_SANDBOX_ROLE TO USER <your_username>;
+```
+
+## Once you have it
+
+Update your CoCo connection defaults so you don't repeat yourself:
+
+```bash
+snow connection set-default my_sandbox
+snow sql --connection my_sandbox -q "USE ROLE MY_SANDBOX_ROLE; USE DATABASE MY_SANDBOX_DB; SELECT CURRENT_DATABASE(), CURRENT_ROLE();"
+```
+
+Then tell CoCo:
+
+> "My sandbox is `MY_SANDBOX_DB` and my role is `MY_SANDBOX_ROLE`. Use these for everything.
+> Create a `RESEARCH` schema and confirm I have build rights."
+
+Next: **`docs/03_identify_your_sources.md`**.

--- a/samples/boxoffice-signal-ml-starter/docs/03_identify_your_sources.md
+++ b/samples/boxoffice-signal-ml-starter/docs/03_identify_your_sources.md
@@ -1,0 +1,51 @@
+# 03 — Research and choose your data sources (with CoCo)
+
+The `sources/` dossiers describe each signal by its characteristics rather than prescribing
+one provider (see `sources/README.md`), because the right source depends on your access,
+budget, and terms. This page is the guided flow to research the best-fitting source for each
+signal and set it up — using Cortex Code as your research partner.
+
+## The loop, per source
+
+1. Open the dossier (`sources/source_X_*.md`) in Cortex Code.
+2. Ask CoCo to **research which provider(s) fit**, from the signal's characteristics.
+3. **You confirm** the current Terms of Service and access rules before ingesting.
+4. Ask CoCo to help you do the **smallest validated first pull**, then load it.
+
+## Research prompts (copy-paste)
+
+**Source A — search & attention demand**
+> "Read `sources/source_A_search_interest.md`. What are my options for a pre-release
+> search/attention demand signal — free and paid? Recommend one for a solo project, explain
+> how to normalize it and disambiguate the title, and help me do one validated pull."
+
+**Source B — trailer conversation**
+> "Read `sources/source_B_trailer_comments.md`. What are my options for pulling public
+> trailer comments, and which official API should I use with my own key? Show me how to pull
+> one trailer, pseudonymize handles, and load to `{{SANDBOX_DB}}.RESEARCH.TRAILER_COMMENTS_RAW`."
+
+**Source C — consumer research pageview demand**
+> "Read `sources/source_C_research_pageviews.md`. What are my options for a consumer-research pageview
+> demand signal with an open API? Help me resolve one film to its canonical page and pull the
+> pre-release window."
+
+**Source D — box office (the label)**
+> "Read `sources/source_D_box_office_history.md`. What are my options for opening-weekend
+> data, and which offer official or licensed access? Help me set one up and a
+> release-date/OW validation check against a second reference."
+
+**Source E — title metadata (use with care)**
+> "Read `sources/source_E_metadata_popularity.md`. What are my options for a title-metadata
+> source? I only want static fields (budget, runtime, genre). Explain why a live popularity
+> score is leakage and keep it out of my feature view."
+
+## Your due-diligence checklist (do this, don't skip)
+
+- [ ] Confirm the source you chose actually fits your access and terms.
+- [ ] Read that provider's **current** Terms of Service and API/scraping policy.
+- [ ] Use **official or licensed** access wherever offered (required for Source D).
+- [ ] Get your **own** key; store it in `.env` (never in git, never in a skill file).
+- [ ] Pseudonymize any user handles (Source B).
+- [ ] Do one small validated pull before bulk ingesting.
+
+Once all sources are identified and access is sorted, go to **`docs/04_stand_up_the_pipeline.md`**.

--- a/samples/boxoffice-signal-ml-starter/docs/04_stand_up_the_pipeline.md
+++ b/samples/boxoffice-signal-ml-starter/docs/04_stand_up_the_pipeline.md
@@ -1,0 +1,96 @@
+# 04 — Stand up the pipeline
+
+By now you have CoCo connected (docs/01), a sandbox (docs/02), and identified sources
+(docs/03). Time to build. Do it conversationally with CoCo — this page is the map.
+
+## 0. Prove your setup works BEFORE you have any data
+
+Standing up five data sources takes real time. Don't spend it not knowing whether your
+environment is sane. The model runs on synthetic data with no Snowflake connection at all:
+
+```bash
+pip install -r model/requirements.txt
+python model/train_ow_model.py --sample
+```
+
+You should see a metric block print with MAPE around 40%. Those numbers describe a
+random-number generator, not films — do not quote them — but if that command works, the
+modeling machinery is fine and every later problem is a data problem.
+
+## 1. Create the schema
+```bash
+snow sql --connection my_sandbox -f sql/00_schema.sql   # after replacing {{SANDBOX_DB}}
+```
+Or ask CoCo: *"Run `sql/00_schema.sql` against my sandbox, substituting my database name."*
+
+## 2. Seed the film spine
+Populate `MOVIE_MAP` and `RELEASE_DATES` for your research set. **Validate every release
+date against a second reference first** (Source D dossier) — a wrong date corrupts the
+entire pre-release window.
+
+## 3. Ingest each signal
+Run the installed skills (see `skills/`), in this order:
+
+| Order | Skill | Fills |
+|---|---|---|
+| 1 | `box-office-history` | `BOX_OFFICE`, `RELEASE_DATES` (label + validated dates) |
+| 2 | `search-interest-normalize` | `ENTITY_IDS`, `SEARCH_INTEREST`, `SEARCH_ANCHOR_BASELINE` |
+| 3 | `research-pageviews` | `PAGEVIEW_DEMAND` |
+| 4 | `comment-ingest-score` | `TRAILER_COMMENTS_RAW` → `TRAILER_COMMENTS_SCORED` |
+| 5 | (metadata, optional/static only) | `MOVIE_METADATA` |
+
+Then record your exclusions in `REMOVE_FROM_MODEL`, with a reason on every row. The one
+that catches everyone: **comments are disabled on a large share of family/animated
+trailers**, so those films have no Source B signal at all. Exclude on the *absence of
+comments*, never on the genre flag — a family film with a real comment thread belongs in
+the set, and a non-family film with comments off does not. There is a copy-paste query for
+this at the bottom of `sql/00_schema.sql`.
+
+## 4. Score comments with Cortex AISQL
+```bash
+snow sql --connection my_sandbox -f sql/20_intent_scoring_aisql.sql
+```
+Ask CoCo to refresh it to the current AISQL syntax and a good available model first.
+
+## 5. MEASURE the classifier before you trust it
+```bash
+snow sql --connection my_sandbox -f sql/30_intent_eval.sql
+```
+Hand-label 150–300 comments into `INTENT_GOLD` and get a macro-F1. This is not optional
+polish — intent classification *is* the method, and an unmeasured classifier means every
+downstream accuracy number has an unmeasured error bar. Watch PASS precision specifically;
+it is the class that fails quietly, and it is half of net intent.
+
+## 6. Build demand percentiles
+```bash
+snow sql --connection my_sandbox -f sql/05_demand_percentiles.sql
+```
+This creates `DEMAND_PERCENTILES` as an auto-computing view over Sources A + C at horizons
+−21/−14/−7/−3 (rolling / peak / velocity / slope). It is the file that enforces as-of
+discipline, so read its header and run its three validation queries. The `pipeline-refresh`
+skill just re-runs this across the film set.
+
+## 7. Assemble the feature view
+```bash
+snow sql --connection my_sandbox -f sql/10_feature_view.sql
+```
+Then sanity-check:
+```sql
+SELECT DAYS_OUT, COUNT(*) AS films, ROUND(AVG(YT_COMMENTS)) AS avg_comments,
+       ROUND(AVG(NET_INTENT_PCT), 2) AS avg_net_intent
+FROM {{SANDBOX_DB}}.RESEARCH.OW_FEATURES
+GROUP BY 1 ORDER BY 1;
+```
+**`avg_comments` must rise from −21 to −3.** If it is flat, the as-of filter is not biting
+(usually a NULL `COMMENT_DATE`) and your comment features are leaking release-week
+conversation into three-weeks-out rows. Run all three leakage tripwires at the bottom of
+`sql/10_feature_view.sql`.
+
+## 8. Keep it fresh
+Use the `pipeline-refresh` skill to update films in the active window (−21..+21 days) and to
+fill opening weekends once films release.
+
+## You're research-ready
+You now have one modeling row **per film per horizon** (−21/−14/−7/−3) with as-of volume,
+decomposed intent, and demand percentiles against a validated label. For a rigorous
+modeling approach, see **`docs/06_model_overview.md`**.

--- a/samples/boxoffice-signal-ml-starter/docs/05_api_keys_with_coco.md
+++ b/samples/boxoffice-signal-ml-starter/docs/05_api_keys_with_coco.md
@@ -1,0 +1,49 @@
+# 05 — Getting and storing API keys (with CoCo)
+
+Once CoCo has helped you identify a source (docs/03), you'll need your **own** credentials
+for some of them. This page is how to get and store them safely. **Keys never go in git or
+in a skill file** — they live in a git-ignored `.env`.
+
+## Which sources need what
+
+| Source | Key needed? | `.env` var |
+|---|---|---|
+| A — search interest | Entity lookup key (client itself often keyless) | `SEARCH_ENTITY_API_KEY` |
+| B — trailer comments | Yes, if using the official platform API | `COMMENT_PLATFORM_API_KEY` |
+| C — consumer research pageviews | No key; just a polite contact string | `PAGEVIEW_CONTACT` |
+| D — box office | Licensed/official access credential | `BOXOFFICE_ACCESS_TOKEN` |
+| E — metadata (static only) | Yes | `METADATA_API_KEY` |
+
+## Ask CoCo to walk you through each one
+
+> "I've identified Source A. Walk me through creating an account with that provider and
+> generating the entity-lookup API key, tell me the free-tier limits and rate limits, and
+> show me exactly what to paste into my `.env` — without putting the key anywhere in the
+> repo."
+
+Repeat per source. CoCo can also help you:
+- test a key with a single minimal request,
+- detect and back off from rate limits,
+- rotate a key if it's ever exposed.
+
+## Storing keys safely
+
+1. `cp .env.example .env` (the copy is git-ignored).
+2. Paste each real value next to its variable in `.env`.
+3. Load them in a shell or script:
+   ```bash
+   set -a; source .env; set +a         # exports vars for local scripts
+   ```
+4. In Python, read via `os.environ["..."]` — never hardcode.
+
+### Prefer secret storage for anything sensitive
+CoCo supports a local secret store so values never appear in conversation. Ask:
+> "Store my `COMMENT_PLATFORM_API_KEY` in the secret store and use it via `secret_env` when
+> you run my ingest, so the value never shows up in the chat or in any file."
+
+## Golden rules
+- **Never** commit `.env`, `*.key`, `*.p8`, or `connections.toml` (`.gitignore` blocks them).
+- **Never** paste a key into a skill file, a source dossier, or a prompt you'll commit.
+- If a key is ever exposed, **rotate it immediately** with the provider.
+
+Next: **`docs/06_model_overview.md`**.

--- a/samples/boxoffice-signal-ml-starter/docs/06_model_overview.md
+++ b/samples/boxoffice-signal-ml-starter/docs/06_model_overview.md
@@ -1,0 +1,186 @@
+# 06 — Model overview
+
+This repo gets you to a research-ready feature set. How you model it is up to you, but here
+is the approach that held up under rigorous, out-of-sample validation — and, just as
+important, the traps that didn't.
+
+## The two signals that carry the weight
+
+- **Comment volume** (Source B): how much organic conversation a trailer generates. This is
+  the single strongest input — it does most of the predictive work on its own.
+- **Net intent** (Source B, via AISQL): the direction of the conversation
+  (theatrical-leaning minus skip-leaning). Weak in isolation, but nearly **independent** of
+  volume — so the little it carries **stacks additively** on top of volume rather than
+  echoing it.
+
+Add **demand percentiles** (Sources A + C) — search interest and consumer research pageviews —
+and you have a demand-forward feature set that doesn't lean on gameable marketing numbers.
+
+### Two things to know about volume before you get excited about it
+
+**1. Test it against paid exposure, not against budget.** The objection to any conversation
+metric is that it might just be a receipt for the media spend. The control that answers this is
+not production budget — a film's negative cost is only loosely coupled to what is spent on
+marketing — it is the trailer's own **view count**, which is the closest public proxy for what a
+studio spent on the platform. On the reference set (116 films with both):
+
+| Quantity | r |
+|---|---|
+| log views ~ log comment volume | **-0.002** |
+| log views ~ log opening weekend | -0.06 |
+| log comments ~ log opening weekend | 0.68 |
+| log comments ~ log OW, **controlling for views** | **0.68** (unchanged) |
+| log views ~ log OW, controlling for comments | -0.09 |
+| comments-per-view ~ log OW | 0.57 |
+
+Paid view volume and comment volume are orthogonal, so controlling for paid exposure is
+mathematically inert — the relationship goes 0.682 to 0.683. A production-budget control does
+bite, softening 0.68 to 0.54, which is reasonable: a bigger film is a bigger cultural event
+before any media is bought.
+
+**Do not control for theater count.** It is tempting as a "release scale" variable and it is the
+wrong choice, because exhibitors allocate screens using demand research and presales. Screen
+count already embeds the market's read on demand, so partialling it out subtracts the very
+quantity you are trying to measure and reports the remainder as your finding. This is
+over-controlling on a variable downstream of the signal, and it will make an honest result look
+weaker than it is.
+
+Two caveats if you replicate this. View counts in the reference set are lifetime totals from a
+single snapshot rather than pre-release figures — that contamination should bias *toward* a
+positive views/OW correlation, so a near-zero result survives it, but it is not a clean
+measurement. And "public view count = paid impressions" is an assumption, not something measured
+here.
+
+**2. Count volume as-of the horizon, but know how small the correction is.** The conversation
+under a trailer is heavily front-loaded, which is what makes this signal a pre-release
+measurement almost by default. On the reference corpus of 3.5M comments: **78% arrive within
+five days** of the trailer going up, 88% within thirty days, and **94% land before the film
+opens** — leaving ~6% post-release.
+
+So the as-of filter in `sql/10` is good hygiene rather than a rescue. It matters for two
+practical reasons and not much else: your own horizon features (−21 vs −3) should differ from
+each other or the horizon grain is meaningless, and if you scrape a film's thread months after
+release you will collect that post-release tail, which is partly a *consequence* of the opening.
+Filter on `COMMENT_DATE` and the question does not arise. Just don't expect removing 6% of
+comments to move a correlation much — on the reference set it moved the budget-controlled figure
+by about a point.
+
+## Measure the intent classifier, or the rest is decoration
+
+Net intent is only as good as the classifier producing it, and classifier quality is the
+most commonly skipped measurement in this kind of work. Hand-label 150–300 comments and run
+`sql/30_intent_eval.sql` for a per-class confusion matrix and macro-F1.
+
+What the reference build found when it finally did this, which is worth knowing before you
+trust your own first pass:
+
+- The production scorer — the one that actually built the model's features — scored
+  **macro-F1 0.65** on a 299-comment gold set. A revised single-call prompt scored **0.85**
+  on the same labels. That is a large amount of headroom sitting in the prompt, not the model.
+- The failure was concentrated in one class: **PASS precision was 0.31**. Two thirds of the
+  comments the classifier called "skip" were actually neutral — mostly general negativity
+  ('this looks awful') being scored as stated avoidance. Since net intent is
+  theatrical *minus* pass, a noisy PASS side corrupts the feature while leaving it looking
+  stable.
+- The single biggest fix was structural: consolidating several independent yes/no calls into
+  **one call that must choose among four labels**. Independent per-label flags over-fire.
+
+Report macro-F1 alongside any model accuracy you publish. And note which number you are
+quoting: accuracy on an intent-stratified gold set and accuracy over the whole corpus differ
+enormously, because ~90% of real comments are neutral and a classifier that answers NEUTRAL
+to everything looks excellent on the second measure.
+
+## What "good" looks like
+
+You will build this, get a number, and have nothing to compare it to. For reference, here is
+where the reference build landed on 122 films under strict walk-forward validation. Read these
+as a comparison point, not a specification — a different film set, a longer history, or better
+features could legitimately land elsewhere.
+
+| Metric | Reference build | Reading |
+|---|---|---|
+| MAPE | ~38% | Aggregate error across films |
+| Median APE | ~35% | Typical film; usually a few points under MAPE |
+| HDR50 coverage | 45–55% | Far under = overconfident bands |
+| ≥$60M signed log-error | slightly negative | Under-predicting the biggest films is normal |
+| Intent macro-F1 | 0.75+ | Below ~0.65 and net intent is mostly noise |
+
+**On individual predictions versus the aggregate.** MAPE is a mean over the whole film set, and
+it tells you nothing about any single film. A well-built model on this data will land some films
+almost exactly — in the reference build one tentpole came in within half a percent — while
+missing others badly. That spread is the normal shape of the problem, not evidence of anything
+wrong. Do not read a near-exact hit as suspicious.
+
+**What is worth a second look is a large, unexplained move in the aggregate.** Leakage is the
+most common cause of an out-of-fold MAPE that lands well below a comparable published baseline,
+and it is also the easiest thing to do by accident here — comment threads and search curves keep
+growing right up to release, so an aggregate that is filtered wrong looks like a modeling win.
+So if your number comes in much better than the reference above, or improves sharply after a
+change to the feature pipeline rather than the model, run the checklist in
+`sql/10_feature_view.sql` before you draw a conclusion from it. It might be a real gain. The
+point is that you cannot tell from the number alone, and the check costs a minute.
+
+`model/train_ow_model.py` prints your metrics next to this reference and points at the checklist
+when the gap is large.
+
+Also worth knowing what you are *not* beating. Published industry tracking ranges for wide
+releases commonly miss by 20–30% themselves, so a ~38% MAPE model is in the same
+neighborhood as the incumbent, not obviously ahead of it. If you want to make a comparative
+claim, collect tracking ranges for your own film set and score both on the same films. This
+repo does not do that for you, and you should not assume the win.
+
+## Validate out-of-sample: walk-forward in time
+
+Do **not** report accuracy from random k-fold cross-validation on all films — it lets the
+model peek at the future. Use **temporal (walk-forward) validation**: sort films by release
+date, train only on films released *before* each one, and predict forward. It's harder and
+lower-scoring, but it's the only number that reflects real prediction-time performance.
+
+> When you compare two models, hold **everything** constant except the thing you're testing
+> — same films, same features, same temporal splits. Comparing a model on an easy film set
+> against another on a hard one produces a flattering lie.
+
+## Architecture note: prefer a distributional regressor over a tier classifier
+
+An early instinct is to classify films into size tiers (small / mid / large) and regress
+within each. That framing **caps the top** — the biggest films get pulled back toward the
+pack and systematically under-predicted. A single model that predicts the opening directly
+and reports a **confidence range** (a distribution, not one number) avoids the ceiling and
+handles blockbusters through the upper band rather than a fragile point estimate.
+
+On matched films under identical walk-forward validation, moving from the tier-classifier
+framing to a distributional one cut average error (MAPE) by a few points — concentrated in
+the **tail** (fewer large misses), with the typical/median error roughly unchanged.
+
+This is the short version. The full framework — the two blended learners, the
+residual-mixture distribution (HDR band / Bayes point / P78 upside), the demand-forward flag
+and point-lift, and the exact validation and flop-safety loss — is in
+**`docs/07_model_architecture.md`**, with a runnable reference implementation in
+**`model/train_ow_model.py`**.
+
+## Pedigree belongs behind demand
+
+Static "pedigree" features (budget, star power, franchise history, a predecessor's gross)
+feel predictive but encourage the model to believe hype. The version that generalized
+**dropped standalone pedigree entirely** and let it re-enter only **gated behind demand**
+(e.g., demand-percentile × star power). If the crowd isn't showing up in the signals,
+pedigree shouldn't rescue the prediction.
+
+## Leakage watch
+
+Exclude any feature contaminated by post-announcement or post-release activity — notably
+things like screen count, which can change up to opening weekend and reflects the
+expectations of buyers and distributors that may or may not be borne out. The same applies
+to a live third-party popularity score (Source E), and to any comment aggregate that is not
+filtered to the horizon.
+
+A useful habit: for every feature, ask *"could this value have been different if the film had
+opened better?"* If yes, it is out. 
+
+## Build it with CoCo
+
+The full architecture and a copy-paste build/backtest prompt live in
+**`docs/07_model_architecture.md`** (reference implementation: `model/train_ow_model.py`).
+In short: point CoCo at `{{SANDBOX_DB}}.RESEARCH.OW_FEATURES`, run the walk-forward backtest,
+and compare the distributional regressor against a tier-classifier baseline on the **same**
+films and splits.

--- a/samples/boxoffice-signal-ml-starter/docs/07_model_architecture.md
+++ b/samples/boxoffice-signal-ml-starter/docs/07_model_architecture.md
@@ -1,0 +1,126 @@
+# 07 — Model architecture
+
+This is the framework that produced the results in `docs/06`. It's a **distributional
+regressor**, not a tier classifier — the switch away from tiering is what removed the
+blockbuster ceiling. Everything below runs on the `OW_FEATURES` view from
+`sql/10_feature_view.sql`. A runnable reference implementation lives in
+`model/train_ow_model.py`; this page explains what it does and why.
+
+## 1. What it predicts
+For each film it emits a **full predictive distribution** of domestic opening weekend, not a
+single number — then derives a point estimate, a confidence band, and an upside figure from
+that distribution. Predicting a distribution (rather than assigning a size tier and
+regressing within it) is what lets the biggest films score high without a per-tier ceiling.
+
+## 2. Validation: strict walk-forward in time
+Never random k-fold — that leaks the future. Instead:
+- Sort films by release date.
+- Use the earliest **~50%** as a base training block.
+- Split the later ~50% into **8 sequential blocks**; predict each block using **only films
+  released before it** (base + earlier blocks).
+- **Time-decay sample weights:** older films count less, `weight = 0.5 ** (age_months / 24)`
+  (a 24-month half-life relative to the fold's cutoff date).
+- **Split on film, not row.** Each film contributes four horizon rows; if they straddle the
+  boundary the model sees a film's own −3 row while predicting its −21 row.
+
+Note that only the later ~50% of films ever get an out-of-fold prediction, so your reported
+`n_films` is about half your set. That is the cost of doing it honestly.
+
+One acknowledged inconsistency: `ElasticNetCV` uses random 5-fold internally for
+hyperparameter selection *within* each temporal training block. That does not leak the future
+into any reported metric — it never touches test rows — but if you want it strictly temporal,
+pass a `TimeSeriesSplit`.
+
+Every accuracy number is out-of-fold under this scheme. When you compare two model variants,
+hold the films, features, and splits identical and change only the one thing you're testing.
+
+## 3. Two base learners (blended)
+Trained on `LOG_OPENING_WEEKEND` inside each fold, with the time-decay weights:
+- **Gradient-boosted trees** — CatBoost regressor, `loss=RMSE, iterations=500, depth=5,
+  learning_rate=0.03, l2_leaf_reg=10`. Captures non-linear interactions.
+- **Regularized linear** — ElasticNetCV (`l1_ratio ∈ {.1,.5,.9}`, 5-fold) on standardized
+  features. A stable, smooth baseline the trees blend against.
+
+Keep the **out-of-fold residuals** of each learner — they define the spread in the next step.
+
+## 4. From two points to a distribution (residual mixture)
+For a film, take each learner's point prediction in log space and add back the pooled OOF
+residuals of that learner, forming a sample of plausible outcomes; pool both learners'
+samples and exponentiate to dollars. From that empirical distribution compute:
+- **HDR50** — the *highest-density region* covering 50% of the mass (the narrowest interval
+  containing half the samples): gives a `[lo, hi]` band and an HDR50 mean.
+- **Bayes point** — the lower-third quantile (`q = 1/3`), a flop-safe central estimate.
+- **Upside (P78)** — the 0.78 quantile, reported as a credible high-end.
+
+The band matters as much as the point: it's how the model expresses confidence, and how it
+handles blockbusters without inflating the point estimate.
+
+**Pool residuals PER HORIZON.** A 21-days-out prediction is genuinely more uncertain than a
+3-days-out one. Pooling all residuals into one bucket borrows the tight late-horizon spread
+to size the wide early-horizon band, so the model reports its most confident-looking
+intervals exactly where it knows least. `train_ow_model.py` scopes the residual pool by
+`DAYS_OUT` and falls back to the global pool only when a horizon has fewer than 30 residuals
+to characterize.
+
+## 4b. Missing features: impute with a flag, never with zero
+Every demand feature here is a percentile. Zero-filling a missing one does not say
+"unknown" — it says *"least-demanded film in the entire set"*, which is an actively wrong
+signal rather than a neutral one, and it is the difference between a film whose search pull
+failed and a film nobody is searching for. Fill with the column median and add an explicit
+`<COL>__MISSING` indicator so the model can learn unobservedness as its own fact. `sql/05`
+deliberately leaves un-computable percentiles NULL rather than coalescing them for the same
+reason.
+
+## 5. Demand-forward flag + point-lift (Tracks B and C)
+A separate **calibrated classifier** estimates `p_large = P(opening ≥ $50M)` (e.g. a
+random forest wrapped in isotonic `CalibratedClassifierCV`, cv=3), trained on the same
+walk-forward folds.
+- **Track B (point-lift for confident large films):** if `p_large ≥ 0.4`, the reported point
+  is `max(HDR50 mean, Q55)` — nudged toward the demand-implied level; otherwise it's the
+  HDR50 mean. This lifts genuine event films **without** raising the flop over-prediction
+  rate on look-alikes.
+- **Track C (upside):** report the P78 quantile as the credible high-end.
+
+A **demand-quality gate** (net intent × demand, already materialized as `QADJ_*`/`NET_X_*`
+in `OW_FEATURES`) is what separates true event films from high-demand hype-flops.
+
+## 6. Feature discipline (baked into OW_FEATURES)
+- **Pedigree is gated behind demand.** Budget, star power, predecessor gross, and IP tier are
+  never standalone features — they enter only through demand interactions (`SEARCH7_X_STAR`,
+  `SEARCH7_X_IP_HIGH`, `SEARCH7_X_PREDOW`, …). If the crowd isn't showing up, pedigree can't
+  rescue the prediction.
+- **No leakage features.** Any signal contaminated by post-announcement/post-release activity
+  (e.g. a live third-party "popularity" score) is excluded — it inflates offline metrics and
+  collapses under walk-forward validation.
+
+## 7. Objective & metrics — optimize for flop-safety
+Over-predicting a flop is worse than under-predicting a hit, so judge on an **asymmetric loss**:
+
+```
+aLoss = mean( r * max(log(pred/actual), 0)  +  max(-log(pred/actual), 0) ),  r = 2
+```
+
+(over-prediction penalized 2×). Report alongside it:
+- **MAPE** and **median APE** (typical error),
+- **low-band over-prediction rate** (share of small films predicted > 1.5× actual),
+- **HDR50 coverage** (share of actuals landing inside the band — should be ≈ 50%),
+- **large-film signed log-error** (bias on actual ≥ $60M).
+
+## 8. Build it with CoCo
+First, prove the machinery runs with no data at all:
+```bash
+python model/train_ow_model.py --sample     # synthetic; expect MAPE ~40%
+```
+Then point it at your own features:
+> "Read `docs/07_model_architecture.md` and `model/train_ow_model.py`. Point it at my
+> `{{SANDBOX_DB}}.RESEARCH.OW_FEATURES` view, run the walk-forward backtest, and report MAPE,
+> median APE, aLoss, HDR50 coverage, and large-film bias. Then compare it against a simple
+> tier-classifier baseline on the same films and splits."
+
+If your MAPE comes in much better than that reference, or improves sharply after a change to the
+feature pipeline rather than the model, walk the checklist at the bottom of
+`sql/10_feature_view.sql` before concluding it is a gain — leakage is the most common cause and
+the cheapest thing to rule out. (Individual films landing near-exact is normal and means nothing
+about leakage; it is the aggregate that is worth interrogating.)
+
+Reference implementation: **`model/train_ow_model.py`** (source-neutral; reads `OW_FEATURES`).

--- a/samples/boxoffice-signal-ml-starter/model/requirements.txt
+++ b/samples/boxoffice-signal-ml-starter/model/requirements.txt
@@ -1,0 +1,5 @@
+catboost>=1.2
+scikit-learn>=1.3
+numpy>=1.24
+pandas>=2.0
+snowflake-connector-python>=3.6

--- a/samples/boxoffice-signal-ml-starter/model/sample_data.py
+++ b/samples/boxoffice-signal-ml-starter/model/sample_data.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Synthetic OW_FEATURES generator — lets you run the model before you have any data.
+
+WHY THIS EXISTS
+Standing up the real pipeline means five separate data-access decisions, each with its
+own terms of service, keys, and rate limits. That is the honest cost of the project, but
+it is a terrible first experience: you cannot tell whether your environment works until
+after all five succeed. This module fabricates a feature table with the same column
+names, grain, and rough correlation structure as the real one, so you can run
+`train_ow_model.py --sample` in ten minutes, watch the metric block print, and then swap
+in real data with confidence that the machinery is fine.
+
+WHAT IT IS NOT
+These are not films. The numbers come from a generative model tuned to look plausible, so:
+  * Do NOT quote any accuracy you get from --sample. It measures nothing about reality.
+  * The effect sizes are deliberately close to the published ones (volume carries most of
+    the signal, net intent is weak and nearly orthogonal) so the metric block lands in a
+    believable range -- which also means an unexpectedly LOW error on sample data points at a
+    bug in the pipeline rather than an improvement, since there is no real signal here to find.
+"""
+import numpy as np
+import pandas as pd
+
+HORIZONS = [-21, -14, -7, -3]
+
+
+def make_sample(n_films: int = 180, seed: int = 7) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+
+    # A latent "how big is this film" factor. Everything observable is a noisy read on it.
+    size = rng.normal(0, 1, n_films)
+
+    # Release dates spread over ~4 years so walk-forward validation has something to bite.
+    start = np.datetime64("2022-01-07")
+    offsets = np.sort(rng.integers(0, 1460, n_films))
+    release = start + offsets.astype("timedelta64[D]")
+
+    # Comment volume: strongly tied to size (this is the workhorse feature).
+    log_vol_final = 6.0 + 1.05 * size + rng.normal(0, 0.72, n_films)
+
+    # Net intent: nearly independent of size, small true effect. Matches the finding that
+    # intent stacks additively rather than echoing volume.
+    net_intent = rng.normal(0, 12, n_films) + 1.5 * size
+
+    # Search / pageview demand: another noisy read on size, correlated with volume.
+    search_latent = 0.85 * size + rng.normal(0, 0.6, n_films)
+    page_latent = 0.80 * size + rng.normal(0, 0.7, n_films)
+
+    budget_log = 17.2 + 0.75 * size + rng.normal(0, 0.5, n_films)
+    star = np.clip(0.5 + 0.25 * size + rng.normal(0, 0.3, n_films), 0, 2)
+    ip_high = (size + rng.normal(0, 0.7, n_films) > 0.8).astype(int)
+    predow_log = np.where(ip_high == 1, 17.0 + 0.6 * size + rng.normal(0, 0.6, n_films), 0.0)
+    genre_action = (rng.random(n_films) < 0.30).astype(int)
+    genre_horror = (rng.random(n_films) < 0.18).astype(int)
+    month = ((offsets % 365) // 30 + 1).clip(1, 12)
+
+    # The label. Volume does most of the work; net intent adds a small independent lift.
+    log_ow = (
+        17.05
+        + 0.62 * (log_vol_final - 6.0)
+        + 0.0055 * net_intent
+        + 0.18 * search_latent
+        + rng.normal(0, 0.45, n_films)
+    )
+    ow = np.exp(log_ow)
+
+    def pctile(x):
+        return pd.Series(x).rank(pct=True).values
+
+    rows = []
+    for h in HORIZONS:
+        # Comment threads GROW toward release: an earlier horizon sees fewer comments.
+        # This is what the as-of filter in sql/10 produces, and reproducing it here means
+        # the sample data exercises the same shape as the real thing.
+        frac = {-21: 0.45, -14: 0.62, -7: 0.82, -3: 1.00}[h]
+        vol = np.maximum(5, np.round(np.exp(log_vol_final) * frac)).astype(int)
+
+        # Demand also ramps, and is noisier further out.
+        ramp = {-21: 0.70, -14: 0.82, -7: 0.93, -3: 1.00}[h]
+        s = search_latent * ramp + rng.normal(0, 0.25 * (1 - ramp) + 0.05, n_films)
+        p = page_latent * ramp + rng.normal(0, 0.25 * (1 - ramp) + 0.05, n_films)
+        ni = net_intent + rng.normal(0, 3, n_films)
+
+        s_r7, s_pk = pctile(s), pctile(s + rng.normal(0, 0.2, n_films))
+        p_pk, p_r7 = pctile(p + rng.normal(0, 0.2, n_films)), pctile(p)
+        qmult = 1 / (1 + np.exp(-0.2 * ni))
+
+        rows.append(pd.DataFrame({
+            "MOVIE_ID": np.arange(1, n_films + 1),
+            "MOVIE_TITLE": [f"Sample Film {i:03d}" for i in range(1, n_films + 1)],
+            "RELEASE_DATE": release,
+            "DAYS_OUT": h,
+            "OPENING_WEEKEND": ow,
+            "LOG_OPENING_WEEKEND": log_ow,
+            "THEATER_COUNT": np.clip((2200 + 900 * size + rng.normal(0, 300, n_films)), 1000, 4500).astype(int),
+            "YT_COMMENTS": vol,
+            "LOG_YT": np.log1p(vol),
+            "AVG_SENT": np.clip(0.05 + 0.02 * ni / 12 + rng.normal(0, 0.2, n_films), -1, 1),
+            "PCT_THEA": np.clip(8 + ni / 2 + rng.normal(0, 3, n_films), 0, 60),
+            "PCT_PASS": np.clip(8 - ni / 2 + rng.normal(0, 3, n_films), 0, 60),
+            "PCT_POS": np.clip(45 + ni / 2 + rng.normal(0, 8, n_films), 0, 100),
+            "PCT_NEG": np.clip(20 - ni / 3 + rng.normal(0, 6, n_films), 0, 100),
+            "NET_INTENT_PCT": ni,
+            "SEARCH_ROLLING_3D_PCTILE": pctile(s + rng.normal(0, 0.15, n_films)),
+            "SEARCH_ROLLING_7D_PCTILE": s_r7,
+            "SEARCH_ROLLING_14D_PCTILE": pctile(s + rng.normal(0, 0.25, n_films)),
+            "SEARCH_PEAK_PCTILE": s_pk,
+            "SEARCH_VEL_PCTILE": pctile(rng.normal(0, 1, n_films)),
+            "SEARCH_SLOPE_PCTILE": pctile(0.3 * size + rng.normal(0, 1, n_films)),
+            "PAGEVIEW_R7D_PCTILE": p_r7,
+            "PAGEVIEW_PEAK_PCTILE": p_pk,
+            "PAGEVIEW_CUM_PCTILE": pctile(p + rng.normal(0, 0.2, n_films)),
+            "PAGEVIEW_VEL_PCTILE": pctile(rng.normal(0, 1, n_films)),
+            "RELEASE_MONTH": month,
+            "IS_PEAK_SEASON": np.isin(month, [5, 6, 7, 11, 12]).astype(int),
+            "RUNTIME": np.clip(110 + 12 * size + rng.normal(0, 12, n_films), 80, 190).astype(int),
+            "GENRE_ACTION_FRANCHISE": genre_action,
+            "GENRE_HORROR": genre_horror,
+            "GENRE_ANIMATION_FAMILY": np.zeros(n_films, int),
+            "GENRE_ORIGINAL": (1 - ip_high),
+            "RATING_G": np.zeros(n_films, int),
+            "RATING_PG": (rng.random(n_films) < 0.2).astype(int),
+            "RATING_PG13": (rng.random(n_films) < 0.5).astype(int),
+            "RATING_R": (rng.random(n_films) < 0.3).astype(int),
+            "QMULT": qmult,
+            "QADJ_SEARCH": s_r7 * qmult,
+            "QADJ_PAGEVIEW": p_pk * qmult,
+            "SEARCH7_X_STAR": s_r7 * star,
+            "SEARCH7_X_IP_HIGH": s_r7 * ip_high,
+            "SEARCH7_X_PREDOW": s_r7 * predow_log,
+            "SEARCH7_X_ACTION": s_r7 * genre_action,
+            "SEARCH7_X_HORROR": s_r7 * genre_horror,
+            "PAGEVIEWPK_X_STAR": p_pk * star,
+            "SENT_X_SEARCH7": (0.05 + 0.02 * ni / 12) * s_r7,
+            "THEA_X_SEARCH7": np.clip(8 + ni / 2, 0, 60) * s_r7,
+            "NET_X_SEARCH7": ni * s_r7,
+            "NET_X_PAGEVIEWPK": ni * p_pk,
+            "SENT_X_PAGEVIEWPK": (0.05 + 0.02 * ni / 12) * p_pk,
+            "THEA_X_PAGEVIEWPK": np.clip(8 + ni / 2, 0, 60) * p_pk,
+        }))
+
+    df = pd.concat(rows, ignore_index=True)
+
+    # Punch realistic holes in the demand columns. Real pulls fail; the model must cope,
+    # and imputing these to zero (a common shortcut) is actively wrong -- see the
+    # impute-with-flag handling in train_ow_model.py.
+    for col in ["SEARCH_VEL_PCTILE", "PAGEVIEW_VEL_PCTILE", "SEARCH_SLOPE_PCTILE"]:
+        mask = rng.random(len(df)) < 0.08
+        df.loc[mask, col] = np.nan
+
+    return df.sort_values(["RELEASE_DATE", "MOVIE_ID", "DAYS_OUT"]).reset_index(drop=True)
+
+
+if __name__ == "__main__":
+    d = make_sample()
+    d.to_csv("model/sample_features.csv", index=False)
+    print(f"wrote model/sample_features.csv  rows={len(d)}  films={d.MOVIE_ID.nunique()}")

--- a/samples/boxoffice-signal-ml-starter/model/train_ow_model.py
+++ b/samples/boxoffice-signal-ml-starter/model/train_ow_model.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Reference implementation of the trailer-signal opening-weekend model.
+
+A distributional regressor with strict walk-forward temporal validation:
+  * two base learners (CatBoost + ElasticNet) blended via a residual mixture,
+  * a full predictive distribution per film -> HDR50 band, Bayes point, P78 upside,
+  * a calibrated demand-forward flag (P(opening >= $50M)) that lifts confident large films,
+  * pedigree already gated behind demand inside the OW_FEATURES view,
+  * judged on an asymmetric flop-safety loss.
+
+Source-neutral: reads whatever you loaded into {DB}.RESEARCH.OW_FEATURES. See
+docs/07_model_architecture.md for the narrative. This is a starting point -- tune it.
+
+Run against your data:
+    python model/train_ow_model.py --connection my_sandbox --database MY_SANDBOX_DB
+
+Run with no data at all (synthetic, ~10 min, proves your environment works):
+    python model/train_ow_model.py --sample
+
+Deps: pip install -r model/requirements.txt
+"""
+import argparse, json, warnings
+import numpy as np, pandas as pd
+warnings.filterwarnings("ignore")
+from sklearn.linear_model import ElasticNetCV
+from sklearn.preprocessing import StandardScaler
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.calibration import CalibratedClassifierCV
+from catboost import CatBoostRegressor
+
+# Columns that are keys/targets, not features
+NON_FEATURES = {"MOVIE_ID", "MOVIE_TITLE", "RELEASE_DATE", "DAYS_OUT",
+                "OPENING_WEEKEND", "LOG_OPENING_WEEKEND", "THEATER_COUNT"}
+LARGE = 50e6          # LARGE+ tier threshold ($50M)
+HALFLIFE_MONTHS = 24  # time-decay half-life for sample weights
+
+# Where the reference build landed on 122 films under strict walk-forward validation. This is a
+# comparison point, not a specification -- a different film set or better features could
+# legitimately land elsewhere. Note that MAPE is a mean over the whole set and says nothing about
+# any single film: a good model will land some films almost exactly and miss others badly, and
+# that spread is the normal shape of this problem. See docs/06.
+REFERENCE_MAPE = 0.38
+REFERENCE_MAPE_RANGE = (0.30, 0.50)
+# A gap this far below the reference is usually leakage rather than a modeling gain, because the
+# as-of filtering is the easiest thing here to get wrong. It is a prompt to check, not a verdict.
+CHECK_MAPE_BELOW = 0.25
+EXPECTED_HDR50_COVERAGE = (0.42, 0.58)
+
+
+def load_features(conn_name, database):
+    import snowflake.connector
+    con = snowflake.connector.connect(connection_name=conn_name)
+    df = pd.read_sql(f"SELECT * FROM {database}.RESEARCH.OW_FEATURES", con)
+    con.close()
+    df.columns = [c.upper() for c in df.columns]
+    df["RELEASE_DATE"] = pd.to_datetime(df["RELEASE_DATE"])
+    return df
+
+
+def prepare_matrix(df, feats):
+    """Impute missing features with a MISSINGness flag instead of zero-filling.
+
+    An earlier version of this script did `df.fillna(0)`. That is worse than it looks:
+    every feature here is a percentile or a rank-like quantity, so 0 does not mean
+    "unknown", it means "bottom of the entire field". A film whose search pull failed was
+    therefore handed to the model as the least-demanded film in the set -- an actively
+    wrong signal rather than a neutral one. Median-fill plus an explicit _MISSING
+    indicator lets the model learn "this was unobserved" as its own fact.
+
+    The median is computed on the full column rather than per fold. That is a small,
+    deliberate simplification: it is a leak of feature-distribution information (not of
+    the label) and it keeps the fold loop readable. If you want it strictly clean, move
+    the median computation inside the fold and fit it on train rows only.
+    """
+    X = df[feats].copy()
+    miss = X.isna()
+    flag_cols = [c for c in feats if miss[c].any()]
+    X = X.fillna(X.median(numeric_only=True))
+    X = X.fillna(0.0)   # a column that is entirely NULL has no median; it carries no info
+    for c in flag_cols:
+        X[f"{c}__MISSING"] = miss[c].astype(float)
+    return X.values.astype(float), list(X.columns)
+
+
+def cbr():
+    return CatBoostRegressor(loss_function="RMSE", verbose=0, random_seed=42,
+                             iterations=500, depth=5, learning_rate=0.03,
+                             l2_leaf_reg=10, thread_count=-1)
+
+
+def walk_forward_splits(df, n_blocks=8):
+    """Sort films by release date; first 50% = base train; predict each of the next
+    n_blocks using only earlier films. Returns list of (train_idx, test_idx) over rows.
+
+    Splitting on FILM, not row, is essential: each film contributes 4 horizon rows and
+    they must never straddle the train/test boundary or the model sees the same film's
+    own -3 row while predicting its -21 row."""
+    first_date = df.groupby("MOVIE_ID")["RELEASE_DATE"].min().sort_values()
+    films = first_date.index.values
+    base = int(0.5 * len(films))
+    rows = {f: np.where(df["MOVIE_ID"].values == f)[0] for f in films}
+    blocks = np.array_split(films[base:], n_blocks)
+    splits = []
+    for i, blk in enumerate(blocks):
+        train_films = np.concatenate([films[:base]] + [blocks[j] for j in range(i)]) if i else films[:base]
+        tr = np.concatenate([rows[f] for f in train_films])
+        te = np.concatenate([rows[f] for f in blk])
+        splits.append((tr, te))
+    return splits
+
+
+def decay_weights(dates, cutoff):
+    age_months = (cutoff - dates).dt.days.values / 30.44
+    return 0.5 ** (age_months / HALFLIFE_MONTHS)
+
+
+def hdr_triple(cb_point, lin_point, cb_res, lin_res):
+    """Residual-mixture distribution -> (lo, hi, hdr50_mean, bayes q1/3, q0.55, p78)."""
+    samples = np.exp(np.concatenate([cb_point + cb_res, lin_point + lin_res]))
+    s = np.sort(samples); n = len(s); k = int(np.floor(0.5 * n))
+    j = int(np.argmin(s[k:] - s[:n - k]))          # narrowest 50% window = HDR50
+    lo, hi = s[j], s[j + k]
+    hdr_mean = s[(s >= lo) & (s <= hi)].mean()
+    return lo, hi, hdr_mean, np.quantile(samples, 1/3), np.quantile(samples, 0.55), np.quantile(samples, 0.78)
+
+
+def aloss(pred, actual, r=2.0):
+    lr = np.log(pred / actual)
+    return float(np.mean(r * np.maximum(lr, 0) + np.maximum(-lr, 0)))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--connection", help="named Snowflake connection")
+    ap.add_argument("--database", help="sandbox database holding RESEARCH.OW_FEATURES")
+    ap.add_argument("--sample", action="store_true",
+                    help="run on synthetic data (no Snowflake needed) to verify the setup")
+    ap.add_argument("--out", default="model/oof_predictions.json")
+    args = ap.parse_args()
+
+    if args.sample:
+        from sample_data import make_sample
+        df = make_sample()
+        print("*** SYNTHETIC DATA. These numbers describe a random-number generator, "
+              "not films. Do not quote them. ***\n")
+    else:
+        if not (args.connection and args.database):
+            ap.error("--connection and --database are required unless you pass --sample")
+        df = load_features(args.connection, args.database)
+
+    feats = [c for c in df.columns if c not in NON_FEATURES and pd.api.types.is_numeric_dtype(df[c])]
+    X, used = prepare_matrix(df, feats)
+    yln = df["LOG_OPENING_WEEKEND"].values
+    ow = df["OPENING_WEEKEND"].values
+    dates = df["RELEASE_DATE"]
+    horizon = df["DAYS_OUT"].values
+    tier_large = (ow >= LARGE).astype(int)
+    n = len(df)
+
+    cb = np.full(n, np.nan); lin = np.full(n, np.nan); p_large = np.full(n, np.nan)
+    for tr, te in walk_forward_splits(df):
+        w = decay_weights(dates.iloc[tr], dates.iloc[tr].max())
+        m = cbr(); m.fit(X[tr], yln[tr], sample_weight=w); cb[te] = m.predict(X[te])
+        sc = StandardScaler().fit(X[tr])
+        # NOTE: ElasticNetCV's internal cv=5 is random k-fold over the TRAINING block only.
+        # That is hyperparameter selection inside an already-temporal fold, not evaluation,
+        # so it does not leak the future into any reported metric. If you want it strictly
+        # temporal, pass a TimeSeriesSplit here instead.
+        en = ElasticNetCV(l1_ratio=[.1, .5, .9], cv=5, max_iter=8000, random_state=42)
+        en.fit(sc.transform(X[tr]), yln[tr], sample_weight=w); lin[te] = en.predict(sc.transform(X[te]))
+        # demand-forward flag: P(opening >= $50M), calibrated
+        if len(np.unique(tier_large[tr])) > 1:
+            clf = CalibratedClassifierCV(
+                RandomForestClassifier(n_estimators=400, min_samples_leaf=2, random_state=42, n_jobs=-1),
+                method="isotonic", cv=3)
+            clf.fit(X[tr], tier_large[tr])
+            p_large[te] = clf.predict_proba(X[te])[:, list(clf.classes_).index(1)]
+        else:
+            p_large[te] = 0.0
+
+    cov = ~np.isnan(cb)
+
+    # HORIZON-SCOPED residual pools. A 21-days-out prediction is genuinely more uncertain
+    # than a 3-days-out one, so pooling all residuals together (as an earlier version did)
+    # borrows the tight late-horizon spread to size the wide early-horizon band and
+    # understates uncertainty exactly where the user most needs it widened. Fall back to
+    # the global pool when a horizon has too few residuals to characterize.
+    res_by_h = {}
+    for h in np.unique(horizon):
+        sel = cov & (horizon == h)
+        if sel.sum() >= 30:
+            res_by_h[h] = ((yln - cb)[sel], (yln - lin)[sel])
+    global_res = ((yln - cb)[cov], (yln - lin)[cov])
+
+    # one row per film at its latest available horizon
+    last = df[cov].sort_values("DAYS_OUT").groupby("MOVIE_ID").tail(1)
+    recs = []
+    for i in last.index:
+        cb_res, lin_res = res_by_h.get(df.at[i, "DAYS_OUT"], global_res)
+        lo, hi, hdr_mean, bayes, q55, p78 = hdr_triple(cb[i], lin[i], cb_res, lin_res)
+        pl = float(p_large[i])
+        point = max(hdr_mean, q55) if pl >= 0.4 else hdr_mean   # Track B lift for confident large films
+        recs.append({"movie_title": df.at[i, "MOVIE_TITLE"], "actual_ow_m": round(ow[i]/1e6, 2),
+                     "predicted_ow_m": round(point/1e6, 2), "bayes_ow_m": round(bayes/1e6, 2),
+                     "hdr_lo_m": round(lo/1e6, 2), "hdr_hi_m": round(hi/1e6, 2),
+                     "upside_p78_m": round(p78/1e6, 2), "p_large": round(pl, 3),
+                     "days_out": int(df.at[i, "DAYS_OUT"])})
+
+    a = np.array([r["actual_ow_m"] for r in recs]) * 1e6
+    p = np.array([r["predicted_ow_m"] for r in recs]) * 1e6
+    ape = np.abs(p - a) / a
+    inband = np.mean([(a[k] >= recs[k]["hdr_lo_m"]*1e6) & (a[k] <= recs[k]["hdr_hi_m"]*1e6)
+                      for k in range(len(recs))])
+    big = a >= 60e6
+    mape = float(ape.mean())
+    print(f"n_films            {len(recs)}")
+    print(f"MAPE               {mape*100:5.1f}%")
+    print(f"median APE         {np.median(ape)*100:5.1f}%")
+    print(f"aLoss (flop-safe)  {aloss(p, a):.3f}")
+    print(f"HDR50 coverage     {inband*100:5.1f}%   (target ~50%)")
+    if big.sum():
+        print(f">=$60M signed-log {np.mean(np.log(p[big]/a[big])):+.3f}   (neg = under-predict)")
+
+    # ── How your numbers compare to the reference build ───────────────────────────
+    print("\n-- vs reference build (MAPE ~38% on 122 films) --")
+    if mape < CHECK_MAPE_BELOW:
+        print(f"   Your MAPE {mape*100:.1f}% is well below the reference. That may be a real gain on a")
+        print("   different film set -- but leakage is the most common cause and it is cheap to rule")
+        print("   out. Worth checking, in this order:")
+        print("   1. Are comment features horizon-filtered? (sql/10 tripwire 1 -- comment")
+        print("      volume must GROW from -21 to -3.)")
+        print("   2. Is COMMENT_DATE populated in TRAILER_COMMENTS_SCORED?")
+        print("   3. Did a post-release feature (screen count, live popularity score, a")
+        print("      final-gross-derived column) reach OW_FEATURES?")
+        print("   4. Do any of a film's own rows appear in both train and test?")
+        print("   Note: individual films landing near-exact is normal and is NOT a symptom of")
+        print("   anything. This check is about the aggregate only.")
+    elif not (REFERENCE_MAPE_RANGE[0] <= mape <= REFERENCE_MAPE_RANGE[1]):
+        print(f"   Your MAPE {mape*100:.1f}% sits outside the reference range "
+              f"{REFERENCE_MAPE_RANGE[0]*100:.0f}-{REFERENCE_MAPE_RANGE[1]*100:.0f}%.")
+        print("   High side is usually thin coverage (check SEARCH_OBS_COUNT in sql/05) or a")
+        print("   film set including limited releases. Not necessarily wrong -- worth a look.")
+    else:
+        print(f"   Your MAPE {mape*100:.1f}% is in the same range as the reference build.")
+    if not (EXPECTED_HDR50_COVERAGE[0] <= inband <= EXPECTED_HDR50_COVERAGE[1]):
+        print(f"   HDR50 coverage {inband*100:.1f}% is off ~50%: the band is "
+              f"{'too narrow (overconfident)' if inband < 0.5 else 'too wide (underconfident)'}.")
+    print("   Reminder: report the intent classifier's macro-F1 (sql/30_intent_eval.sql)")
+    print("   alongside these numbers. An unmeasured input classifier is an unmeasured error bar.")
+
+    json.dump(recs, open(args.out, "w"), indent=1)
+    print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    import os, sys
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    main()

--- a/samples/boxoffice-signal-ml-starter/prompts/coco_prompt_library.md
+++ b/samples/boxoffice-signal-ml-starter/prompts/coco_prompt_library.md
@@ -1,0 +1,107 @@
+# CoCo prompt library
+
+Copy-paste prompts for building the pipeline with Cortex Code. Fill in `{{SANDBOX_DB}}` and
+your role. Order roughly follows `docs/01`→`06`.
+
+---
+
+## Setup
+
+**Connect & orient**
+> "Read `COCO.md` and `docs/`. Summarize what we're building and confirm my Snowflake
+> connection works. My sandbox is `{{SANDBOX_DB}}`, role `{{SANDBOX_ROLE}}`."
+
+**Sandbox request**
+> "I don't have a sandbox yet. Using `docs/02`, draft the exact message and the grant SQL my
+> data team needs, scoped to full build rights inside one database only."
+
+**Create schema**
+> "Run `sql/00_schema.sql` against `{{SANDBOX_DB}}`, substituting the database name. Then
+> list the tables you created and confirm they're empty."
+
+---
+
+## Research the sources
+
+**Source A — search & attention demand**
+> "Read `sources/source_A_search_interest.md`. What are my options for a pre-release
+> search/attention signal, free and paid? Recommend one, explain how to normalize it and
+> disambiguate the title, and do one validated pull for a test film."
+
+**Source B — trailer conversation**
+> "Read `sources/source_B_trailer_comments.md`. What are my options, and which official API
+> should I use? Pull one trailer's comments with my key, pseudonymize handles, load to
+> `TRAILER_COMMENTS_RAW`."
+
+**Source C — consumer research pageview demand**
+> "Read `sources/source_C_research_pageviews.md`. What are my options for a consumer-research pageview
+> demand signal with an open API? Resolve one film to its canonical page and pull the
+> pre-release window."
+
+**Source D — box office**
+> "Read `sources/source_D_box_office_history.md`. What are my options, and which offer
+> official/licensed access? Set one up and a date/OW validation check against a second
+> reference."
+
+**Source E — title metadata (use with care)**
+> "Read `sources/source_E_metadata_popularity.md`. What are my options? Pull static fields
+> only and explain why a live popularity score is leakage."
+
+---
+
+## Ingest & process
+
+**Score comments with AISQL**
+> "Update `sql/20_intent_scoring_aisql.sql` to current Cortex AISQL syntax and a good
+> available model, run it, and show me per-film volume + net intent %."
+
+**Demand percentiles**
+> "Run `sql/05_demand_percentiles.sql` against my sandbox, then run its three validation
+> queries and tell me whether any film has thin coverage or a horizon that moved when I
+> refreshed."
+
+**Evaluate the intent classifier (do not skip)**
+> "Help me build a 200-comment gold set stratified by predicted label from
+> `TRAILER_COMMENTS_SCORED`, then run `sql/30_intent_eval.sql` and show me macro-F1 and the
+> confusion matrix. If PASS precision is under 0.6, propose three prompt changes and test each
+> on a 500-comment sample before I rescore everything."
+
+**Feature view**
+> "Run `sql/10_feature_view.sql` and sanity-check `OW_FEATURES` — row count, avg comment
+> volume, avg net intent, and any films missing signals."
+
+**Refresh**
+> "Use the `pipeline-refresh` skill to find films releasing in the next 3 weeks and refresh
+> all their signals; fill opening weekends for films that already released."
+
+---
+
+## Keys & safety
+
+> "Walk me through getting my own key for Source <X>, tell me its rate limits, store it in
+> the secret store, and use it via `secret_env` so the value never appears in chat or files."
+
+---
+
+## Model (build the framework)
+
+**Prove the machinery first — no data required**
+> "Run `python model/train_ow_model.py --sample` and explain what each metric in the output
+> means and what would make it move."
+
+> "Read `docs/07_model_architecture.md` and `model/train_ow_model.py`. Point it at my
+> `{{SANDBOX_DB}}.RESEARCH.OW_FEATURES`, run the walk-forward backtest, and report MAPE,
+> median APE, aLoss, HDR50 coverage, and large-film bias. Keep pedigree gated behind demand
+> and exclude leakage features."
+
+> "Now compare this distributional regressor against a simple tier-classifier baseline on the
+> SAME films and walk-forward splits, so I can see what the architecture change buys."
+
+**Interrogate your own result**
+> "My MAPE came in at X%. Walk the leakage checklist in `sql/10_feature_view.sql` and the build
+> check in `train_ow_model.py` and tell me whether this number is believable."
+
+> "Compute the correlation between LN(trailer views) and LN(comment volume) on my film set, then
+> the partial correlation of LN(comment volume) with LN(opening weekend) controlling for LN(trailer
+> views), and tell me whether comment volume is just a proxy for paid media. Then do the same with
+> LN(budget) as the control. Do NOT control for theater count and explain why not."

--- a/samples/boxoffice-signal-ml-starter/skills/README.md
+++ b/samples/boxoffice-signal-ml-starter/skills/README.md
@@ -1,0 +1,33 @@
+# Skills — sanitized, installable CoCo skills
+
+These are portable versions of the skills used to build the original pipeline, with all
+provider names, API keys, personal info, and internal database identifiers removed and
+replaced by placeholders. Each captures the **method**, not anyone's data.
+
+## Install a skill into Cortex Code Desktop
+
+1. Copy a skill folder (e.g. `search-interest-normalize/`) into your CoCo skills directory
+   (`~/.snowflake/cortex/skills/` on macOS), or open this repo in CoCo and ask:
+   > "Install the skill in `skills/search-interest-normalize/` for me."
+2. Fill in placeholders the first time you use it:
+   - `{{SANDBOX_DB}}`, `{{SCHEMA}}` — your sandbox (docs/02).
+   - `{{SEARCH_INTEREST_LIB}}`, `{{ENTITY_LOOKUP_API}}`, `{{COMMENT_PLATFORM}}`,
+     `{{PAGEVIEW_API}}`, `{{BOXOFFICE_SOURCE}}`, `{{METADATA_API}}` — the source you choose
+     for each signal, which CoCo helps you compare using the `sources/` dossiers (docs/03).
+   - Keys come from your git-ignored `.env`.
+
+## What's here
+
+| Skill | Purpose | Dossier |
+|---|---|---|
+| `search-interest-normalize` | Pull + normalize a search/attention demand signal | Source A |
+| `comment-ingest-score` | Ingest trailer comments, pseudonymize, AISQL sentiment/intent | Source B |
+| `research-pageviews` | Pull daily pageviews, build demand percentiles | Source C |
+| `box-office-history` | Obtain the label via **licensed/official** access + validation | Source D |
+| `pipeline-refresh` | Orchestrate the active-window refresh across all signals | all |
+
+## Sanitization guarantee
+
+None of these files contain real API keys, tokens, account locators, emails, provider
+names, or internal database/schema/table names. If you find one, it's a bug — please open
+an issue. See the repo's pre-push scan in `docs/03`/the project notes.

--- a/samples/boxoffice-signal-ml-starter/skills/box-office-history/SKILL.md
+++ b/samples/boxoffice-signal-ml-starter/skills/box-office-history/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: box-office-history
+description: "Obtain box-office history (opening weekend + release dates) via licensed/official access and validate it. Use for: box office, opening weekend, the label, release dates, target variable. Triggers: box office, opening weekend, label, release date validation."
+---
+
+# Box-Office History (Source D — the label)
+
+Obtain the **target** (domestic opening weekend), plus theater count and validated release
+dates. Read `sources/source_D_box_office_history.md` first.
+
+Confirm the provider's current Terms of Service before any programmatic access.
+
+## Prerequisites
+- Sandbox tables: `BOX_OFFICE`, `RELEASE_DATES` (from `sql/00_schema.sql`).
+
+## Load
+Write per film: `OPENING_WEEKEND` (dollars), `THEATER_COUNT`, `MOVIE_TITLE` → `BOX_OFFICE`;
+`RELEASE_DATE` → `RELEASE_DATES`.
+
+## Validation discipline (this bit earlier versions)
+- **Validate release dates against a second reference** before pulling any pre-release
+  signal — a wrong date silently corrupts the days-out window and the release-month feature.
+- **Verify opening-weekend figures independently** after release. A prior audit of a
+  training set found fabricated OW values and corrupted dates. Never trust a fresh value
+  from a single source.
+
+```sql
+-- Flag suspicious rows for manual review
+SELECT b.MOVIE_ID, b.MOVIE_TITLE, b.OPENING_WEEKEND, r.RELEASE_DATE
+FROM {{SANDBOX_DB}}.{{SCHEMA}}.BOX_OFFICE b
+JOIN {{SANDBOX_DB}}.{{SCHEMA}}.RELEASE_DATES r USING (MOVIE_ID)
+WHERE b.OPENING_WEEKEND <= 0
+   OR b.THEATER_COUNT < 1000
+   OR r.RELEASE_DATE IS NULL;
+```
+

--- a/samples/boxoffice-signal-ml-starter/skills/comment-ingest-score/SKILL.md
+++ b/samples/boxoffice-signal-ml-starter/skills/comment-ingest-score/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: comment-ingest-score
+description: "Ingest public trailer comments and score them with Snowflake Cortex AISQL into sentiment + intent. Use for: trailer comments, comment ingestion, sentiment, intent classification, AISQL scoring, pseudonymize handles. Triggers: comments, trailer conversation, intent, sentiment, AISQL."
+---
+
+# Comment Ingest + Score (Source B)
+
+Ingest public trailer-comment threads and turn them into the project's core signal:
+**volume** + **decomposed intent**. Read `sources/source_B_trailer_comments.md` first and
+ask CoCo to compare the platform options and choose one with an official API.
+
+## Prerequisites
+- `COMMENT_PLATFORM_API_KEY` in `.env` (preferred: official platform API).
+- Sandbox tables: `TRAILER_COMMENTS_RAW`, `TRAILER_COMMENTS_SCORED` (from `sql/00_schema.sql`).
+- Access to Cortex AISQL (docs/02).
+
+## Step 1 — Ingest (prefer the official API)
+```python
+import os, hashlib
+KEY = os.environ["COMMENT_PLATFORM_API_KEY"]
+def pseudonymize(handle: str) -> str:
+    return hashlib.sha256(handle.encode()).hexdigest()[:16]   # store hash, never raw handle
+# Pull comments for a trailer video via {{COMMENT_PLATFORM}}'s official API, paginating.
+# For each comment keep: video_id, comment_id, author_hash, text, like_count, date.
+```
+- **COMMENT_DATE is not optional.** It is what makes horizon-correct features possible. A
+  comment with no date cannot be placed relative to the release and will either leak into
+  early horizons or be dropped.
+- If you must use a browser-DOM path instead of the API, respect ToS/robots/rate limits
+  and still pseudonymize. Do not hammer the platform.
+- Load rows to `{{SANDBOX_DB}}.{{SCHEMA}}.TRAILER_COMMENTS_RAW`.
+- **Record films whose comments are disabled** in `REMOVE_FROM_MODEL` with reason
+  `comments_disabled`. This hits many family/animated trailers. Exclude on the absence of
+  comments, never on the genre flag — see `sources/source_B_trailer_comments.md`.
+
+## Step 2 — Score with Cortex AISQL
+Run `sql/20_intent_scoring_aisql.sql` (ask CoCo to refresh it to current AISQL syntax and a
+good available model). It classifies each comment into a sentiment score/bucket and an
+intent flag set: `THEATRICAL_INTENT`, `STREAMING_INTENT`, `PASS_INTENT`.
+
+Why intent, not raw positivity: generic praise ("can't wait!!") is the *least* predictive
+text, and planted hype only pushes one way. Classifying **intent** is what makes the signal
+hard to game.
+
+## Step 3 — Measure the classifier (do this before Step 4)
+Run `sql/30_intent_eval.sql` against 150–300 hand-labeled comments in `INTENT_GOLD` and read
+the macro-F1 and per-class confusion matrix. Watch **PASS precision** in particular: general
+negativity ('this looks awful') getting scored as stated avoidance is the most common way net
+intent gets quietly corrupted, and net intent is theatrical *minus* pass. In the reference
+build the production scorer sat at macro-F1 0.65 with PASS precision 0.31, while a revised
+single-call prompt reached 0.85 on the same labels.
+
+## Step 4 — Per-film features (as-of the horizon)
+```sql
+-- Per-film totals are fine for a quick look, but the MODEL needs them per horizon.
+-- sql/10_feature_view.sql does that; this is the eyeball version.
+SELECT MOVIE_ID,
+       COUNT(*)                                            AS comment_volume,
+       AVG(SENTIMENT_SCORE)                                AS avg_sent,
+       100.0*(AVG(THEATRICAL_INTENT) - AVG(PASS_INTENT))   AS net_intent_pct
+FROM {{SANDBOX_DB}}.{{SCHEMA}}.TRAILER_COMMENTS_SCORED
+GROUP BY MOVIE_ID;
+```
+Volume does most of the predictive work — though roughly half of its raw correlation with
+opening weekend is budget and release scale, so control for those before believing the
+headline number (`docs/06`). Net intent is weak alone but nearly independent of volume, so it
+stacks additively.
+

--- a/samples/boxoffice-signal-ml-starter/skills/pipeline-refresh/SKILL.md
+++ b/samples/boxoffice-signal-ml-starter/skills/pipeline-refresh/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: pipeline-refresh
+description: "Orchestrate an active-window refresh of all trailer-signal sources for upcoming films. Use for: refresh pipeline, update data, active window, which films need data, pre-release refresh. Triggers: refresh, update movies, active window, data gaps, pipeline refresh."
+---
+
+# Pipeline Refresh (all sources)
+
+Find films in the active release window (−21 to +21 days from today) and refresh every
+signal for them, then update the label for films that have opened. Orchestrates the other
+four skills.
+
+## Prerequisites
+- Sandbox schema created (`sql/00_schema.sql`) and the four ingest skills installed.
+- Sources identified via CoCo (docs/03).
+
+## Step 0 — Find active films and their gaps
+```sql
+SELECT m.MOVIE_ID, m.MOVIE_TITLE, rd.RELEASE_DATE,
+       DATEDIFF('day', CURRENT_DATE(), rd.RELEASE_DATE)         AS DAYS_UNTIL_RELEASE,
+       IFF(e.ENTITY_ID IS NULL, 'MISSING', e.ENTITY_ID)         AS ENTITY_STATUS,
+       (SELECT MAX(OBS_DATE) FROM {{SANDBOX_DB}}.{{SCHEMA}}.SEARCH_INTEREST s
+         WHERE s.MOVIE_ID = m.MOVIE_ID)                          AS SEARCH_MAX_DATE,
+       (SELECT COUNT(*) FROM {{SANDBOX_DB}}.{{SCHEMA}}.TRAILER_COMMENTS_SCORED c
+         WHERE c.MOVIE_ID = m.MOVIE_ID)                          AS COMMENTS_SCORED,
+       (SELECT MAX(OBS_DATE) FROM {{SANDBOX_DB}}.{{SCHEMA}}.PAGEVIEW_DEMAND p
+         WHERE p.MOVIE_ID = m.MOVIE_ID)                          AS PAGEVIEW_MAX_DATE
+FROM {{SANDBOX_DB}}.{{SCHEMA}}.MOVIE_MAP m
+JOIN {{SANDBOX_DB}}.{{SCHEMA}}.RELEASE_DATES rd USING (MOVIE_ID)
+LEFT JOIN {{SANDBOX_DB}}.{{SCHEMA}}.ENTITY_IDS e USING (MOVIE_ID)
+WHERE m.MOVIE_ID NOT IN (SELECT MOVIE_ID FROM {{SANDBOX_DB}}.{{SCHEMA}}.REMOVE_FROM_MODEL)
+  AND rd.RELEASE_DATE BETWEEN DATEADD('day',-21,CURRENT_DATE()) AND DATEADD('day',21,CURRENT_DATE());
+```
+
+## Step 1 — Refresh, per film (order matters)
+1. **Validate release date** against a second reference (Source D) — do this first.
+2. `search-interest-normalize` — refresh Source A (entity ID must exist).
+3. `research-pageviews` — refresh Source C.
+4. `comment-ingest-score` — refresh + score Source B.
+5. Rebuild `DEMAND_PERCENTILES` by re-running `sql/05_demand_percentiles.sql` (it is a view, so
+   this is only needed if you changed the definition — otherwise it recomputes on read).
+6. For films now past release: `box-office-history` — fill/verify `OPENING_WEEKEND`.
+7. Add any newly-discovered exclusions to `REMOVE_FROM_MODEL` with a reason — most commonly
+   `comments_disabled` for trailers with the comment section switched off.
+
+## Step 2 — Rebuild features and check for leaks
+Refresh the `OW_FEATURES` view (`sql/10_feature_view.sql`) and spot-check a few films. Then run
+the tripwire at the bottom of that file:
+
+```sql
+SELECT DAYS_OUT, COUNT(*) AS films, ROUND(AVG(YT_COMMENTS)) AS avg_comments
+FROM {{SANDBOX_DB}}.{{SCHEMA}}.OW_FEATURES GROUP BY 1 ORDER BY 1;
+```
+`avg_comments` must rise from −21 to −3. Flat means the as-of filter is not biting — usually a
+NULL `COMMENT_DATE` — and your backtest is being fed release-week conversation.
+
+Refreshing is exactly when as-of discipline breaks, because you are adding recent data to films
+whose early horizons are already fixed. A film's −21 percentile should not move because you
+pulled new data today. `sql/05` has an as-of proof query for this.
+
+## Conventions
+- Titles are Title Case everywhere; never insert UPPERCASE.
+- Tell the user what you'll do before doing it.
+- Keep raw pulls out of git; pseudonymize comment handles.

--- a/samples/boxoffice-signal-ml-starter/skills/research-pageviews/SKILL.md
+++ b/samples/boxoffice-signal-ml-starter/skills/research-pageviews/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: research-pageviews
+description: "Pull daily consumer-research pageviews for films and build demand percentiles in Snowflake. Use for: pageviews, research pageview demand, page-traffic, demand percentiles. Triggers: pageviews, page traffic, research demand, demand curve."
+---
+
+# Research Pageviews (Source C)
+
+Pull daily pageview counts for each film's information/research page and turn them into
+robust **demand percentiles**. Read `sources/source_C_research_pageviews.md` first and ask
+CoCo to compare the available page-traffic APIs and pick one with daily granularity.
+
+## Prerequisites
+- No API key needed; set a descriptive `PAGEVIEW_CONTACT` in `.env` per provider etiquette.
+- Sandbox tables: `PAGEVIEW_DEMAND`, `DEMAND_PERCENTILES` (from `sql/00_schema.sql`).
+
+## Step 1 — Resolve the canonical page title
+Titles need exact matching (spaces↔underscores, disambiguation like "(film)" or a year).
+Resolve redirects to the canonical title before pulling.
+
+## Step 2 — Pull daily views for the pre-release window
+```python
+import os, requests
+CONTACT = os.environ.get("PAGEVIEW_CONTACT", "you@example.com")
+HEADERS = {"User-Agent": f"trailer-signal-research/1.0 ({CONTACT})"}   # polite identification
+def daily_views(article, start, end):
+    url = "{{PAGEVIEW_API}}"          # CoCo fills the source-specific per-page daily endpoint
+    r = requests.get(url.format(article=article, start=start, end=end), headers=HEADERS, timeout=15)
+    return r.json()                   # -> [{date, views}, ...]
+# Counts are ABSOLUTE (real views) — cache them; history doesn't change.
+```
+Load to `{{SANDBOX_DB}}.{{SCHEMA}}.PAGEVIEW_DEMAND`.
+
+## Step 3 — Build demand percentiles by horizon
+Align to days-out (−21/−14/−7/−3), then convert to percentiles across the film set to tame
+the huge dynamic range: cumulative, 7-day rolling, peak-day, velocity. Write to
+`DEMAND_PERCENTILES` (columns `PAGEVIEW_R7D_PCTILE`, `PAGEVIEW_PEAK_PCTILE`, `PAGEVIEW_CUM_PCTILE`, ...).
+
+## Etiquette
+- Send the contact string; keep request rates polite; cache aggressively.

--- a/samples/boxoffice-signal-ml-starter/skills/search-interest-normalize/SKILL.md
+++ b/samples/boxoffice-signal-ml-starter/skills/search-interest-normalize/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: search-interest-normalize
+description: "Pull and normalize a pre-release search/attention demand signal for films into Snowflake. Use for: search interest, attention data, demand index, normalization, continuous baseline. Triggers: search interest, attention, demand signal, normalize interest."
+---
+
+# Search-Interest Normalize (Source A)
+
+Pull a **pre-release search/attention** signal for each film and normalize it into a
+continuous, comparable demand timeline in Snowflake. Read `sources/source_A_search_interest.md`
+first and ask CoCo to compare the available sources and pick one before you build.
+
+## Prerequisites
+- Access to your chosen interest source (`SEARCH_ENTITY_API_KEY` in `.env` if it needs a key;
+  many client libraries are keyless but need a locale/timezone config).
+- Sandbox tables from `sql/00_schema.sql`: `ENTITY_IDS`, `SEARCH_INTEREST`, `SEARCH_ANCHOR_BASELINE`.
+
+## Step 1 — Disambiguate the title
+Track the film, not unrelated searches that share its name. If your source offers a stable
+topic/entity ID or exact-match mode, resolve each title to that ID first and store it in
+`ENTITY_IDS`. Ask CoCo for the lookup that fits your source; keep any key in `.env`, never
+hardcoded.
+
+## Step 2 — Normalize for comparability
+If your source returns a *relative* index (rescaled per request), separate pulls won't share
+a scale. The general fix, which CoCo will tailor to your source:
+- include a **stable, high-volume reference term** in each per-film pull, and
+- separately pull that reference term on its own over a long window to build a continuous
+  baseline (`SEARCH_ANCHOR_BASELINE`),
+- then normalize each film's series against the reference so everything lands on one scale.
+
+If your source returns absolute counts, you can skip the normalization and store directly.
+
+## Step 3 — Load & derive features
+Write results to `{{SANDBOX_DB}}.{{SCHEMA}}.SEARCH_INTEREST` (Title Case titles; never
+UPPERCASE), then build rolling/peak/velocity demand percentiles by horizon (see
+`pipeline-refresh`).
+
+## Gotchas
+- Expect rate-limiting; back off and retry.
+- Validate a new film's pull against the source's own UI before trusting it.
+- A wrong release date corrupts the ±window — validate dates first (Source D).

--- a/samples/boxoffice-signal-ml-starter/sources/README.md
+++ b/samples/boxoffice-signal-ml-starter/sources/README.md
@@ -1,0 +1,41 @@
+# Data source dossiers
+
+The files in this folder describe each signal the pipeline uses **by its characteristics**,
+rather than prescribing one provider. Teams differ in the data access, budget, and terms
+they have, and some providers restrict how their data may be accessed — so the kit stays
+provider-neutral and helps you research the option that fits, under your own access.
+
+Each dossier covers **what the signal is**, how it's typically accessed, the kinds of
+providers that offer it, the gotchas that matter, and the schema columns it feeds. That's
+enough for Cortex Code to lay out your options when you ask — and then to help you set up the
+one you choose against **your own** access.
+
+## The research pattern
+
+Open the repo in Cortex Code and ask, for any dossier:
+
+> "Read `sources/source_A_search_interest.md`. Based on these characteristics, what public
+> data sources and Python client libraries could I use? Compare the options, then help me
+> obtain access and do the smallest first pull to validate the one I pick."
+
+CoCo will suggest the likely options, the access method, and the client, then walk you
+through setup. Repeat per source. The full prompt set is in `../prompts/coco_prompt_library.md`.
+
+## Why dossiers instead of a fixed list?
+
+- It keeps the kit **provider-neutral** — you choose the source that fits your access,
+  budget, and terms, and nothing here implies an endorsement of any provider.
+- It builds in a moment of due diligence: when CoCo suggests a source, **you** confirm its
+  current Terms of Service and access rules before ingesting. Signals age; ToS change.
+
+## The five signals
+
+| Dossier | Signal | In the model? |
+|---|---|---|
+| `source_A_search_interest.md` | Normalized search-interest index per title | Yes (demand) |
+| `source_B_trailer_comments.md` | Public trailer-comment volume + AI-scored intent | Yes (the core signal) |
+| `source_C_research_pageviews.md` | Consumer research pageview demand | Yes (demand) |
+| `source_D_box_office_history.md` | Historical grosses + opening weekends (the label) | Yes (target + history) |
+| `source_E_metadata_popularity.md` | Third-party metadata popularity score | **No — excluded as leakage** |
+
+Read `docs/03_identify_your_sources.md` for the guided flow.

--- a/samples/boxoffice-signal-ml-starter/sources/source_A_search_interest.md
+++ b/samples/boxoffice-signal-ml-starter/sources/source_A_search_interest.md
@@ -1,0 +1,61 @@
+# Source A — Pre-release search & attention demand
+
+## The signal
+How much the public is actively searching for or looking up a film in the weeks before it
+opens. A rising interest curve ahead of release is one of the strongest, hardest-to-game
+demand proxies you can get.
+
+## Options CoCo can help you choose from
+Several public and commercial services expose pre-release interest/attention data. Ask CoCo
+and it will lay out the common choices with their trade-offs — free vs. paid, an official
+API vs. a community client library, geographic coverage, history depth, and rate limits —
+then help you pick one that fits your access and budget. Most solo research projects land on
+a widely-used free interest index; paid attention-data vendors are alternatives when you
+need higher resolution or a guaranteed SLA.
+
+## Things to sort out with whichever you pick
+- **Comparability.** Some interest sources return a *relative* index (rescaled per request)
+  rather than absolute counts, so two separate pulls aren't on the same scale. The usual fix
+  is to include a stable, high-volume reference term in each pull and normalize against a
+  standalone baseline of that reference — CoCo will tailor the exact method to your source.
+- **Disambiguation.** Track the *film*, not every search that happens to share its title.
+  Most sources offer a stable topic/entity ID or an exact-match mode; prefer that over
+  free-text, which pulls in unrelated results.
+- **Access.** May need an API key plus a locale/timezone config; expect throttling, so build
+  in backoff and validate a new title's pull against the source's own UI before trusting it.
+
+## Known failure modes (as of 2026-07)
+This is the signal that breaks most often, and the failures are not graceful. Budget real
+time here — it is where the reference build lost the most hours.
+
+- **The obvious free community client library for the best-known free interest index is
+  currently broken**, not merely rate-limited. Expect hard HTTP 429s on nearly every request,
+  and separately an incompatibility with modern HTTP-client library versions that surfaces as
+  an import or connection-pool error rather than an honest "too many requests". Do not spend a
+  day assuming you misconfigured it. Ask CoCo to check the library's current issue tracker
+  *before* you build against it.
+- **When the API path is unavailable, a manual export path still works.** The provider's own UI
+  will hand you a CSV for a small set of terms over a date range. Tedious, doesn't scale to
+  hundreds of films, but reliable — and for a research set you refresh weekly it is entirely
+  workable. Plan for a hybrid: bulk history by hand once, incremental pulls automated if and
+  when the API cooperates.
+- **Silent scale changes.** A relative index can rescale between pulls with no error raised.
+  Always re-pull the anchor term alongside each film, and alert on any week where the anchor's
+  own baseline moves more than you'd expect. An unnoticed rescale corrupts the whole batch.
+- **A NULL is not a zero.** If the anchor floors out, the normalized value is undefined — store
+  NULL. Coalescing to 0 tells the model this was the least-searched film in the set, which is a
+  wrong answer masquerading as a neutral one.
+
+None of this is in the provider's documentation. It's in issue trackers and other people's blog
+posts — tell CoCo to look there, not just at the API reference.
+
+## Feeds these columns
+- `SEARCH_INTEREST`, `SEARCH_ANCHOR_BASELINE`, `ENTITY_IDS`
+- Downstream: rolling / peak / velocity **demand percentiles by horizon** (−21/−14/−7/−3 days)
+  in `DEMAND_PERCENTILES`, built by `sql/05_demand_percentiles.sql`.
+
+## Ask CoCo
+> "Read `sources/source_A_search_interest.md`. What are my options for a pre-release
+> search/attention demand signal? Compare a couple of free and paid choices, recommend one
+> for a solo research project, explain how to normalize it and disambiguate the title, and
+> help me pull a validated sample for one film."

--- a/samples/boxoffice-signal-ml-starter/sources/source_B_trailer_comments.md
+++ b/samples/boxoffice-signal-ml-starter/sources/source_B_trailer_comments.md
@@ -1,0 +1,80 @@
+# Source B — Trailer conversation (volume + AI-scored intent)
+
+This is the **core signal** of the project: the organic conversation under a film's trailer.
+Two things matter — **how much** conversation there is (volume) and **which way** it leans
+(intent).
+
+## The signal
+Public comments posted under official trailer videos: short free text, usually with an
+author handle and a like/vote count, often thousands of them for a big title.
+
+## Options CoCo can help you choose from
+The conversation lives on the major online video platforms and, to a lesser extent, social
+and forum sites. Ask CoCo for the options and it will compare access paths — an official
+platform **data API** (preferred, with your own key) vs. rendering the page and reading the
+comment section from the DOM — along with their rate limits and terms. Comments typically
+load dynamically, so a raw HTML fetch won't contain them; you'll use the API or a rendered
+page.
+
+## The processing that makes it useful (Snowflake Cortex AISQL)
+Raw comments alone are weak and noisy — the value comes from **classifying** them. A single
+AISQL pass scores each comment into:
+- **sentiment** (a score and a bucket: positive / neutral / negative), and
+- **intent**: `THEATRICAL` ("opening night", "seeing this in IMAX"), `STREAMING` ("wait for
+  streaming"), or `PASS` ("hard pass").
+
+From the scored table you derive, per film: comment **volume**, **net intent %**
+(theatrical-leaning minus skip-leaning), and sentiment mix. See `docs/06_model_overview.md`.
+
+## Why intent beats raw sentiment (and resists gaming)
+Planted hype is generic ("can't wait!!"), and generic praise is the *least* predictive text
+in the data. Manipulators also push in one direction, inflating blunt counts while leaving
+the decomposed intent signal intact underneath. Classifying *intent* rather than counting
+*positivity* is what makes the signal hard to fake.
+
+## Access & etiquette
+- Prefer an **official API** with your own key. If you read from a rendered page instead,
+  respect the platform's terms, `robots.txt`, and rate limits — don't hammer it.
+- **Pseudonymize author handles** on ingest (hash them). Store only what the model needs.
+
+## Known failure modes (as of 2026-07)
+
+- **Comments are disabled on a large share of family and animated trailers.** This is the
+  biggest surprise in the whole pipeline and it is a structural absence, not a low count:
+  those films have *no* Source B signal, ever. Handle it by excluding on **comment
+  availability**, never on the genre flag — a family film whose trailer has a real comment
+  thread belongs in your set, and a non-family film with comments switched off does not.
+  Filtering by an `ANIMATION_FAMILY` flag instead is the easy mistake and it silently discards
+  films that carry usable signal. There is a copy-paste exclusion query at the bottom of
+  `sql/00_schema.sql`.
+- **Forum and aggregator archive endpoints are unreliable.** The community mirrors people reach
+  for when a platform's own API is inconvenient are, as of this writing, variously returning
+  400s, 429s, 403s, and timeouts under light load. If your design depends on one of them, it
+  will break. Prefer an official API with your own key; treat archives as a bonus, not a
+  foundation.
+- **A raw HTML fetch will not contain the comments.** They load dynamically. Either use the API
+  or render the page.
+- **The conversation is front-loaded, which works in your favor.** On the reference corpus of
+  3.5M comments, 78% arrive within five days of the trailer going up and 94% land before the film
+  opens. That is why this signal is essentially a pre-release measurement by the shape of the
+  behavior rather than by force. Still store `COMMENT_DATE` on every row and aggregate as-of each
+  horizon (`sql/10_feature_view.sql` does): if you scrape a thread months after release you pick
+  up the ~6% post-release tail, which is partly a *consequence* of the opening, and your horizon
+  features are meaningless if they don't differ from each other. Just don't expect the filter to
+  swing a correlation — on the reference set it moved things by about a point.
+- **Measure the classifier.** See `sql/30_intent_eval.sql`. The reference build's production
+  scorer turned out to be at macro-F1 0.65 while a revised prompt hit 0.85 on the same labels,
+  with almost all of the damage in one class. You will not discover that by reading output.
+
+## Feeds these columns
+- `TRAILER_COMMENTS_RAW` (text, pseudonymized author, like count, video/movie id, **comment date**).
+- `TRAILER_COMMENTS_SCORED` (+ `COMMENT_DATE`, `SENTIMENT_SCORE`, `SENTIMENT_BUCKET`,
+  `THEATRICAL_INTENT`, `STREAMING_INTENT`, `PASS_INTENT`).
+- `INTENT_GOLD` (your hand labels, for `sql/30_intent_eval.sql`).
+
+## Ask CoCo
+> "Read `sources/source_B_trailer_comments.md`. What are my options for pulling public
+> trailer comments, and which official API should I use with my own key? Show me how to
+> ingest comments for one trailer, pseudonymize handles, load to
+> `{{SANDBOX_DB}}.RESEARCH.TRAILER_COMMENTS_RAW`, and score them with Cortex AISQL into
+> sentiment + intent."

--- a/samples/boxoffice-signal-ml-starter/sources/source_C_research_pageviews.md
+++ b/samples/boxoffice-signal-ml-starter/sources/source_C_research_pageviews.md
@@ -1,0 +1,31 @@
+# Source C — Consumer research pageview activity
+
+## The signal
+How many people are pulling up a film's information page to research it in the run-up to
+release — pageview activity as a demand proxy. Like search interest, a rising curve is a
+clean, hard-to-game signal, and these counts are usually **absolute**, so they compare
+directly across films and dates.
+
+## Options CoCo can help you choose from
+Several public sources publish **page-traffic / pageview APIs** for the pages people visit
+to research a title. Ask CoCo for the options and it will point you to one with an open API
+and daily granularity, and note the etiquette each expects.
+
+## Things to sort out with whichever you pick
+- **Exact matching.** Pages have canonical titles with quirks (spacing, disambiguation
+  suffixes, release-year variants) and redirects — resolve to the canonical page first.
+- **Turn counts into features.** Pull daily views across the pre-release window, align to
+  days-out horizons (−21/−14/−7/−3), then convert to **percentiles across your film set**
+  (cumulative, rolling, peak, velocity) so the huge dynamic range doesn't dominate.
+- **Etiquette.** These APIs are often keyless but ask for a descriptive contact string and
+  polite request rates. History doesn't change, so cache aggressively.
+
+## Feeds these columns
+- `PAGEVIEW_DEMAND` (per movie, per date)
+- Downstream: demand percentiles by horizon in `DEMAND_PERCENTILES`.
+
+## Ask CoCo
+> "Read `sources/source_C_research_pageviews.md`. What are my options for a consumer-research
+> pageview demand signal with an open API? Help me resolve one film to its canonical page,
+> pull daily views for the pre-release window, and load them to
+> `{{SANDBOX_DB}}.RESEARCH.PAGEVIEW_DEMAND`."

--- a/samples/boxoffice-signal-ml-starter/sources/source_D_box_office_history.md
+++ b/samples/boxoffice-signal-ml-starter/sources/source_D_box_office_history.md
@@ -1,0 +1,37 @@
+# Source D — Box-office results (the label)
+
+## The signal
+The target the model predicts: **domestic opening weekend**, plus historical grosses,
+theater counts (to filter wide releases), and accurate release dates.
+
+## Options CoCo can help you choose from
+Box-office results are published by several industry trackers and are available as licensed
+datasets and, in some cases, official APIs. Ask CoCo for the options and their access terms,
+and pick the one that fits. A practical note: some popular trackers **restrict automated
+access**, so prefer an **official or licensed** feed, a properly licensed dataset, or manual
+curation of the handful of figures your research set needs. Confirm a source's current Terms
+of Service before any programmatic access.
+
+## Data-quality discipline (don't skip this)
+- **Validate release dates against a second reference.** A wrong date silently corrupts the
+  entire pre-release feature window and the release-month feature.
+- **Verify opening-weekend figures independently.** Never trust a single fresh value — a
+  past audit of a training set turned up fabricated grosses and corrupted dates. Cross-check
+  before you train on anything.
+
+```sql
+-- Flag suspicious rows for manual review
+SELECT b.MOVIE_ID, b.MOVIE_TITLE, b.OPENING_WEEKEND, r.RELEASE_DATE
+FROM {{SANDBOX_DB}}.{{SCHEMA}}.BOX_OFFICE b
+JOIN {{SANDBOX_DB}}.{{SCHEMA}}.RELEASE_DATES r USING (MOVIE_ID)
+WHERE b.OPENING_WEEKEND <= 0 OR b.THEATER_COUNT < 1000 OR r.RELEASE_DATE IS NULL;
+```
+
+## Feeds these columns
+- `BOX_OFFICE` (`OPENING_WEEKEND`, `THEATER_COUNT`, `MOVIE_TITLE`)
+- `RELEASE_DATES` (`RELEASE_DATE`, validated)
+
+## Ask CoCo
+> "Read `sources/source_D_box_office_history.md`. What are my options for domestic
+> opening-weekend data, and which offer official or licensed access? Help me set one up and
+> build a release-date + opening-weekend validation check against a second reference."

--- a/samples/boxoffice-signal-ml-starter/sources/source_E_metadata_popularity.md
+++ b/samples/boxoffice-signal-ml-starter/sources/source_E_metadata_popularity.md
@@ -1,0 +1,30 @@
+# Source E — Title metadata & popularity (use with care)
+
+This one is here mostly as a **cautionary note**: a source that looks helpful but whose
+headline metric you should keep out of the model.
+
+## The signal
+Structured metadata about a title — budget, runtime, genre, cast, ratings — often bundled
+with a platform-computed **"popularity" score** that updates continuously.
+
+## Options CoCo can help you choose from
+Several movie metadata databases and catalog APIs provide these fields. Ask CoCo for the
+options; most solo projects use one keyed metadata API for **static** attributes only.
+
+## Why the popularity score is a trap (leakage)
+A live popularity score looks like a strong predictor, and early versions leaned on it — but
+it's contaminated by activity that co-moves with the outcome (it reflects buzz that itself
+responds to the release). Feeding it in inflates offline accuracy and **leaks** signal you
+won't have cleanly at prediction time; under walk-forward validation it doesn't hold up. The
+current model **drops it entirely**.
+
+Use such a source for **static fields** (budget, runtime, genre, cast) if you need them —
+just never feed the live popularity metric into the model.
+
+## Feeds these columns
+- `MOVIE_METADATA` (static fields only — note there is intentionally **no** popularity column).
+
+## Ask CoCo
+> "Read `sources/source_E_metadata_popularity.md`. What are my options for a title-metadata
+> source? I only want static fields (budget, runtime, genre). Explain why a live popularity
+> score is a leakage risk and make sure it never enters my feature view."

--- a/samples/boxoffice-signal-ml-starter/sql/00_schema.sql
+++ b/samples/boxoffice-signal-ml-starter/sql/00_schema.sql
@@ -1,0 +1,200 @@
+-- 00_schema.sql — source-agnostic schema for the trailer-signal pipeline.
+-- No data. Replace {{SANDBOX_DB}} with your sandbox database (see docs/02).
+-- Run in Cortex Code or: snow sql --connection my_sandbox -f sql/00_schema.sql
+--
+-- Naming is deliberately provider-neutral: SEARCH_* = search/attention demand (Source A),
+-- PAGEVIEW_* = consumer-research pageview demand (Source C). Nothing here is a live
+-- popularity score — that's excluded as leakage (see sources/source_E_metadata_popularity.md).
+
+USE DATABASE {{SANDBOX_DB}};
+CREATE SCHEMA IF NOT EXISTS RESEARCH;
+USE SCHEMA RESEARCH;
+
+-- ---------------------------------------------------------------------------
+-- Identity / spine
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS MOVIE_MAP (
+    MOVIE_ID        NUMBER        PRIMARY KEY,
+    MOVIE_TITLE     STRING        NOT NULL          -- Title Case; keep consistent everywhere
+);
+
+CREATE TABLE IF NOT EXISTS RELEASE_DATES (
+    MOVIE_ID        NUMBER        PRIMARY KEY,
+    RELEASE_DATE    DATE          NOT NULL           -- VALIDATE against a 2nd reference (Source D)
+);
+
+-- ---------------------------------------------------------------------------
+-- Source D — box office (target + history)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS BOX_OFFICE (
+    MOVIE_ID        NUMBER        PRIMARY KEY,
+    MOVIE_TITLE     STRING,
+    OPENING_WEEKEND FLOAT,                            -- domestic OW in dollars (the label)
+    THEATER_COUNT   NUMBER                            -- for wide-release filtering
+);
+
+-- ---------------------------------------------------------------------------
+-- Source A — search / attention interest (relative index) + normalization scaffolding
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ENTITY_IDS (
+    MOVIE_ID        NUMBER        PRIMARY KEY,
+    MOVIE_TITLE     STRING,
+    RELEASE_DATE    DATE,
+    ENTITY_ID       STRING,                           -- stable topic/entity id (NOT free text)
+    ENTITY_NAME     STRING,
+    MATCH_STATUS    STRING
+);
+
+CREATE TABLE IF NOT EXISTS SEARCH_INTEREST (
+    MOVIE_ID        NUMBER,
+    OBS_DATE        DATE,
+    INTEREST        FLOAT,                            -- movie interest, co-scaled with anchor
+    ANCHOR_INTEREST FLOAT,                            -- anchor term, same-scale within the pull
+    PRIMARY KEY (MOVIE_ID, OBS_DATE)
+);
+
+CREATE TABLE IF NOT EXISTS SEARCH_ANCHOR_BASELINE (
+    OBS_DATE        DATE          PRIMARY KEY,
+    ANCHOR_NORM     FLOAT                             -- normalized continuous anchor timeline
+);
+
+-- ---------------------------------------------------------------------------
+-- Source B — trailer comments (raw + AI-scored)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS TRAILER_COMMENTS_RAW (
+    MOVIE_ID        NUMBER,
+    VIDEO_ID        STRING,
+    COMMENT_ID      STRING,
+    AUTHOR_HASH     STRING,                           -- PSEUDONYMIZED handle (hash, never raw)
+    COMMENT_TEXT    STRING,
+    LIKE_COUNT      NUMBER,
+    COMMENT_DATE    DATE
+);
+
+CREATE TABLE IF NOT EXISTS TRAILER_COMMENTS_SCORED (
+    MOVIE_ID          NUMBER,
+    COMMENT_ID        STRING,
+    COMMENT_TEXT      STRING,
+    LIKE_COUNT        NUMBER,
+    COMMENT_DATE      DATE,                           -- CARRY THIS THROUGH. Without it you
+                                                      -- cannot build horizon-correct comment
+                                                      -- features and your backtest will leak.
+    SENTIMENT_SCORE   FLOAT,                          -- -1..1 (mapped from AI_SENTIMENT label)
+    SENTIMENT_BUCKET  STRING,                         -- 'positive' | 'neutral' | 'negative' | 'mixed'
+    THEATRICAL_INTENT NUMBER,                         -- 1/0
+    STREAMING_INTENT  NUMBER,                         -- 1/0
+    PASS_INTENT       NUMBER                          -- 1/0  (NEUTRAL comment = all three 0)
+);
+
+-- ---------------------------------------------------------------------------
+-- Source C — consumer research pageview activity
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS PAGEVIEW_DEMAND (
+    MOVIE_ID        NUMBER,
+    OBS_DATE        DATE,
+    VIEWS           NUMBER,                           -- absolute daily views
+    PRIMARY KEY (MOVIE_ID, OBS_DATE)
+);
+
+-- ---------------------------------------------------------------------------
+-- Static attributes & pedigree (per film)
+-- Your own catalog and/or Source E static fields. NOTE: intentionally NO live
+-- popularity score — that co-moves with the outcome and leaks (see source_E).
+-- In the model, the raw pedigree columns (budget/star/predecessor/IP) are NOT used
+-- standalone — they enter ONLY through demand-gated interactions in OW_FEATURES.
+--
+-- NO SKILL FILLS THIS TABLE. It is deliberately hand-built from your own catalog plus
+-- Source E static fields, because star power and IP tier are judgement calls you should
+-- make explicitly rather than inherit from a vendor score. Two consequences to know:
+--   * If you leave it empty, sql/10 still runs (LEFT JOIN) but every demand-gated
+--     pedigree interaction is NULL and the model loses that whole family. That is a
+--     legitimate starting configuration — the demand signals carry most of the weight.
+--   * GENRE_PRESTIGE is used by sql/10 to scope out awards-season films. If you never
+--     populate it, nothing is filtered and your set will include limited-release
+--     prestige titles whose openings follow completely different mechanics.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS MOVIE_METADATA (
+    MOVIE_ID              NUMBER PRIMARY KEY,
+    RUNTIME               NUMBER,
+    BUDGET                FLOAT,
+    BUDGET_LOG            FLOAT,
+    -- star power (from your own cast/history source)
+    MAX_STAR_POWER        FLOAT,
+    TOP2_STAR_POWER       FLOAT,
+    AVG_STAR_POWER        FLOAT,
+    NUM_STARS_WITH_HISTORY NUMBER,
+    -- franchise / prior title
+    PREDECESSOR_OW        FLOAT,
+    PREDECESSOR_OW_LOG    FLOAT,
+    -- IP tier flags (one-hot)
+    KNOWN_IP_TIER         NUMBER,
+    IP_HIGH_PROFILE       NUMBER,
+    IP_MODERATE           NUMBER,
+    IP_NICHE              NUMBER,
+    IP_ORIGINAL           NUMBER,
+    IS_MAJOR_STUDIO       NUMBER,
+    -- genre flags (one-hot)
+    GENRE_ACTION_FRANCHISE NUMBER,
+    GENRE_HORROR          NUMBER,
+    GENRE_ANIMATION_FAMILY NUMBER,
+    GENRE_ORIGINAL        NUMBER,
+    GENRE_PRESTIGE        NUMBER,
+    -- rating flags (one-hot)
+    RATING_G              NUMBER,
+    RATING_PG             NUMBER,
+    RATING_PG13           NUMBER,
+    RATING_R              NUMBER
+);
+
+-- ---------------------------------------------------------------------------
+-- Gold labels for evaluating the intent classifier (see sql/30_intent_eval.sql).
+-- The intent classification IS the method. If you do not measure it, you are
+-- trusting a prompt. Hand-label 100-300 comments here before you believe any
+-- downstream accuracy number.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS INTENT_GOLD (
+    COMMENT_ID      STRING        PRIMARY KEY,
+    COMMENT_TEXT    STRING,
+    GOLD_INTENT     STRING,                           -- THEATRICAL | STREAMING | PASS | NEUTRAL
+    LABELED_BY      STRING,
+    LABELED_AT      TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP()
+);
+
+-- ---------------------------------------------------------------------------
+-- Derived demand percentiles by pre-release horizon (from Source A + Source C).
+-- One row per (MOVIE_ID, DAYS_OUT); DAYS_OUT in (-21, -14, -7, -3).
+--
+-- NOT CREATED HERE. This is an auto-computing VIEW built by sql/05_demand_percentiles.sql,
+-- because the as-of windowing that keeps each horizon honest is the whole substance of
+-- it -- a bare table invites hand-populating it wrong. Run sql/05 after loading Sources
+-- A and C, and before sql/10_feature_view.sql.
+-- ---------------------------------------------------------------------------
+
+-- Films to exclude from the model. WRITE A REASON EVERY TIME -- the exclusion policy is
+-- a modeling decision, not housekeeping, and an undocumented one is indistinguishable
+-- from fitting the film set to the answer you wanted.
+--
+-- The exclusion that matters most, and that surprises everyone: COMMENT AVAILABILITY.
+-- Comments are disabled on a large share of family/animated trailers, so those films
+-- have no Source B signal at all -- not a low signal, an absent one. Exclude on the
+-- ABSENCE OF COMMENTS, never on the genre flag:
+--   * a family film whose trailer has a real comment thread SHOULD be in the set;
+--   * a non-family film with comments disabled MUST be out.
+-- Excluding by GENRE_ANIMATION_FAMILY instead is the easy mistake and it silently drops
+-- films that carry usable signal. See sources/source_B_trailer_comments.md.
+--
+-- Suggested REASON vocabulary: 'comments_disabled', 're_release', 'limited_release',
+-- 'bad_release_date', 'no_search_entity', 'day_and_date_streaming'.
+CREATE TABLE IF NOT EXISTS REMOVE_FROM_MODEL (
+    MOVIE_ID        NUMBER        PRIMARY KEY,
+    REASON          STRING        NOT NULL
+);
+
+-- Populate the comment-availability exclusions once Source B is loaded:
+--   INSERT INTO REMOVE_FROM_MODEL (MOVIE_ID, REASON)
+--   SELECT m.MOVIE_ID, 'comments_disabled'
+--   FROM MOVIE_MAP m
+--   LEFT JOIN (SELECT MOVIE_ID, COUNT(*) n FROM TRAILER_COMMENTS_RAW GROUP BY 1) c
+--          ON c.MOVIE_ID = m.MOVIE_ID
+--   WHERE COALESCE(c.n, 0) < 25
+--     AND m.MOVIE_ID NOT IN (SELECT MOVIE_ID FROM REMOVE_FROM_MODEL);

--- a/samples/boxoffice-signal-ml-starter/sql/05_demand_percentiles.sql
+++ b/samples/boxoffice-signal-ml-starter/sql/05_demand_percentiles.sql
@@ -1,0 +1,176 @@
+-- 05_demand_percentiles.sql — build DEMAND_PERCENTILES from Source A (search interest)
+-- and Source C (research pageviews). Replace {{SANDBOX_DB}}.
+--
+-- THIS IS THE TRANSFORM THAT MAKES THE FEATURE VIEW WORK. Run it after you have loaded
+-- SEARCH_INTEREST / SEARCH_ANCHOR_BASELINE and PAGEVIEW_DEMAND, and before sql/10.
+--
+-- What it does, and why each choice matters:
+--
+--  1. AS-OF DISCIPLINE. One row per (MOVIE_ID, DAYS_OUT) for DAYS_OUT in (-21,-14,-7,-3).
+--     Every aggregate for a horizon uses ONLY observations dated on or before that
+--     horizon's as-of date. This is the whole point: a -21 row must not be able to see
+--     day -4. If you break this, your backtest will look excellent and mean nothing.
+--
+--  2. NORMALIZATION. If your search source returns a per-request relative index, each
+--     pull has its own scale. SCALED puts every film on one timeline by dividing by the
+--     anchor term that rode along in the same pull, then multiplying by that anchor's
+--     standalone baseline. If your source returns absolute counts, set
+--     USE_ANCHOR_NORMALIZATION to FALSE below and INTEREST is used as-is.
+--
+--  3. PERCENTILES, NOT LEVELS. Raw demand spans several orders of magnitude and drifts
+--     with platform-wide seasonality. PERCENT_RANK within a horizon compresses that to
+--     0..1 and makes films comparable across years.
+--
+--     ⚠ KNOWN CAVEAT — read this. PERCENT_RANK is computed across your WHOLE film set,
+--     which means a 2023 film's percentile is influenced by films released in 2025.
+--     That is a mild look-ahead. It is acceptable for research (the ranking is over a
+--     demand distribution, not over the label) and it is what the reference build does,
+--     but it is NOT strictly clean. If you want the strict version, see the
+--     EXPANDING-WINDOW variant at the bottom of this file and use that instead.
+
+USE SCHEMA {{SANDBOX_DB}}.RESEARCH;
+
+SET USE_ANCHOR_NORMALIZATION = TRUE;   -- FALSE if your Source A returns absolute counts
+SET LOOKBACK_DAYS = 90;                -- window for peak / cumulative aggregates
+
+CREATE OR REPLACE VIEW DEMAND_PERCENTILES AS
+WITH horizons AS (
+    SELECT -21 AS DAYS_OUT UNION ALL SELECT -14 UNION ALL SELECT -7 UNION ALL SELECT -3
+),
+film_horizon AS (
+    SELECT rd.MOVIE_ID,
+           rd.RELEASE_DATE,
+           h.DAYS_OUT,
+           DATEADD(day, h.DAYS_OUT, rd.RELEASE_DATE) AS ASOF_DATE
+    FROM RELEASE_DATES rd
+    CROSS JOIN horizons h
+    WHERE rd.MOVIE_ID NOT IN (SELECT MOVIE_ID FROM REMOVE_FROM_MODEL)
+),
+-- ── Source A: put every film's relative index on one common scale ──────────────
+search_norm AS (
+    SELECT s.MOVIE_ID,
+           s.OBS_DATE,
+           CASE
+             WHEN NOT $USE_ANCHOR_NORMALIZATION THEN s.INTEREST
+             WHEN s.ANCHOR_INTEREST > 0
+               THEN s.INTEREST / s.ANCHOR_INTEREST * COALESCE(b.ANCHOR_NORM, 100)
+             ELSE NULL            -- anchor floored out: unusable, do NOT coalesce to 0
+           END AS SCALED
+    FROM SEARCH_INTEREST s
+    LEFT JOIN SEARCH_ANCHOR_BASELINE b ON b.OBS_DATE = s.OBS_DATE
+),
+search_agg AS (
+    SELECT f.MOVIE_ID,
+           f.DAYS_OUT,
+           AVG(IFF(sn.OBS_DATE >  DATEADD(day,  -3, f.ASOF_DATE), sn.SCALED, NULL)) AS S_R3,
+           AVG(IFF(sn.OBS_DATE >  DATEADD(day,  -7, f.ASOF_DATE), sn.SCALED, NULL)) AS S_R7,
+           AVG(IFF(sn.OBS_DATE >  DATEADD(day, -14, f.ASOF_DATE), sn.SCALED, NULL)) AS S_R14,
+           AVG(IFF(sn.OBS_DATE <= DATEADD(day,  -7, f.ASOF_DATE)
+               AND  sn.OBS_DATE >  DATEADD(day, -14, f.ASOF_DATE), sn.SCALED, NULL)) AS S_PRIOR7,
+           MAX(sn.SCALED)                                                            AS S_PEAK,
+           COUNT(sn.SCALED)                                                          AS S_OBS
+    FROM film_horizon f
+    JOIN search_norm sn
+      ON sn.MOVIE_ID = f.MOVIE_ID
+     AND sn.OBS_DATE <= f.ASOF_DATE                                    -- ← as-of guard
+     AND sn.OBS_DATE >  DATEADD(day, -$LOOKBACK_DAYS, f.ASOF_DATE)
+    GROUP BY 1, 2
+),
+-- ── Source C: absolute daily pageviews ────────────────────────────────────────
+pageview_agg AS (
+    SELECT f.MOVIE_ID,
+           f.DAYS_OUT,
+           AVG(IFF(p.OBS_DATE >  DATEADD(day,  -7, f.ASOF_DATE), p.VIEWS, NULL))  AS P_R7,
+           AVG(IFF(p.OBS_DATE <= DATEADD(day,  -7, f.ASOF_DATE)
+               AND  p.OBS_DATE >  DATEADD(day, -14, f.ASOF_DATE), p.VIEWS, NULL))  AS P_PRIOR7,
+           MAX(p.VIEWS)                                                            AS P_PEAK,
+           SUM(p.VIEWS)                                                            AS P_CUM,
+           COUNT(p.VIEWS)                                                          AS P_OBS
+    FROM film_horizon f
+    JOIN PAGEVIEW_DEMAND p
+      ON p.MOVIE_ID = f.MOVIE_ID
+     AND p.OBS_DATE <= f.ASOF_DATE                                     -- ← as-of guard
+     AND p.OBS_DATE >  DATEADD(day, -$LOOKBACK_DAYS, f.ASOF_DATE)
+    GROUP BY 1, 2
+),
+-- ── derived shape metrics (velocity = short vs prior window, slope = log trend) ──
+metrics AS (
+    SELECT f.MOVIE_ID,
+           f.DAYS_OUT,
+           s.S_R3, s.S_R7, s.S_R14, s.S_PEAK,
+           IFF(s.S_PRIOR7 > 0, s.S_R7 / s.S_PRIOR7 - 1, NULL)                 AS S_VEL,
+           IFF(s.S_R14 > 0 AND s.S_R3 > 0, LN(s.S_R3) - LN(s.S_R14), NULL)     AS S_SLOPE,
+           p.P_R7, p.P_PEAK, p.P_CUM,
+           IFF(p.P_PRIOR7 > 0, p.P_R7 / p.P_PRIOR7 - 1, NULL)                 AS P_VEL,
+           COALESCE(s.S_OBS, 0) AS S_OBS,
+           COALESCE(p.P_OBS, 0) AS P_OBS
+    FROM film_horizon f
+    LEFT JOIN search_agg   s ON s.MOVIE_ID = f.MOVIE_ID AND s.DAYS_OUT = f.DAYS_OUT
+    LEFT JOIN pageview_agg p ON p.MOVIE_ID = f.MOVIE_ID AND p.DAYS_OUT = f.DAYS_OUT
+)
+SELECT
+    MOVIE_ID,
+    DAYS_OUT,
+    -- Source A percentiles. NULL metrics stay NULL — PERCENT_RANK would rank a missing
+    -- value as the bottom of the field, which is a wrong signal, not a neutral one.
+    IFF(S_R3    IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY S_R3))    AS SEARCH_ROLLING_3D_PCTILE,
+    IFF(S_R7    IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY S_R7))    AS SEARCH_ROLLING_7D_PCTILE,
+    IFF(S_R14   IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY S_R14))   AS SEARCH_ROLLING_14D_PCTILE,
+    IFF(S_PEAK  IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY S_PEAK))  AS SEARCH_PEAK_PCTILE,
+    IFF(S_VEL   IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY S_VEL))   AS SEARCH_VEL_PCTILE,
+    IFF(S_SLOPE IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY S_SLOPE)) AS SEARCH_SLOPE_PCTILE,
+    -- Source C percentiles
+    IFF(P_R7    IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY P_R7))    AS PAGEVIEW_R7D_PCTILE,
+    IFF(P_PEAK  IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY P_PEAK))  AS PAGEVIEW_PEAK_PCTILE,
+    IFF(P_CUM   IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY P_CUM))   AS PAGEVIEW_CUM_PCTILE,
+    IFF(P_VEL   IS NULL, NULL, PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ORDER BY P_VEL))   AS PAGEVIEW_VEL_PCTILE,
+    -- coverage counters: keep these, they are how you catch a film with a broken pull
+    S_OBS AS SEARCH_OBS_COUNT,
+    P_OBS AS PAGEVIEW_OBS_COUNT
+FROM metrics;
+
+
+-- ---------------------------------------------------------------------------
+-- Validation — run these before you trust the output.
+-- ---------------------------------------------------------------------------
+-- 1. Every film should have exactly 4 horizon rows.
+--    SELECT DAYS_OUT, COUNT(*) FROM DEMAND_PERCENTILES GROUP BY 1 ORDER BY 1;
+--
+-- 2. Coverage: films with thin pulls will quietly poison the percentile field.
+--    SELECT COUNT_IF(SEARCH_OBS_COUNT < 14) AS thin_search,
+--           COUNT_IF(PAGEVIEW_OBS_COUNT < 14) AS thin_pageview
+--    FROM DEMAND_PERCENTILES WHERE DAYS_OUT = -3;
+--
+-- 3. AS-OF PROOF (the important one). A film's -21 percentile must not move when you
+--    later load data from its release week. Snapshot, reload, compare:
+--    CREATE TEMP TABLE _asof_check AS
+--      SELECT MOVIE_ID, SEARCH_ROLLING_7D_PCTILE FROM DEMAND_PERCENTILES WHERE DAYS_OUT = -21;
+--    -- ...refresh Source A for recent films, then:
+--    SELECT COUNT(*) AS rows_that_moved
+--    FROM _asof_check a JOIN DEMAND_PERCENTILES d USING (MOVIE_ID)
+--    WHERE d.DAYS_OUT = -21
+--      AND ABS(COALESCE(a.SEARCH_ROLLING_7D_PCTILE,-1) - COALESCE(d.SEARCH_ROLLING_7D_PCTILE,-1)) > 0.02;
+--    Expect 0 from newly-arrived post-horizon observations. A non-zero count from films
+--    whose OWN pre-horizon history was backfilled is fine; anything else is a leak.
+
+
+-- ---------------------------------------------------------------------------
+-- STRICT VARIANT (optional) — expanding-window percentiles.
+-- Ranks each film only against films released BEFORE it, removing the look-ahead
+-- described in the header. Slower and noisier for early films (a film ranked against
+-- 20 predecessors has a coarse percentile), which is why it is not the default.
+-- Swap the PERCENT_RANK() OVER (PARTITION BY DAYS_OUT ...) calls above for this shape:
+--
+--   , ranked AS (
+--       SELECT m.*, rd.RELEASE_DATE
+--       FROM metrics m JOIN RELEASE_DATES rd USING (MOVIE_ID)
+--   )
+--   SELECT MOVIE_ID, DAYS_OUT,
+--          (SELECT AVG(IFF(p.S_R7 < r.S_R7, 1.0, 0.0))
+--             FROM ranked p
+--            WHERE p.DAYS_OUT = r.DAYS_OUT
+--              AND p.RELEASE_DATE < r.RELEASE_DATE) AS SEARCH_ROLLING_7D_PCTILE
+--   FROM ranked r;
+--
+-- Ask CoCo: "rewrite sql/05 using the expanding-window variant and rerun the backtest —
+-- tell me how much MAPE moves." If it moves a lot, the look-ahead was doing work.

--- a/samples/boxoffice-signal-ml-starter/sql/10_feature_view.sql
+++ b/samples/boxoffice-signal-ml-starter/sql/10_feature_view.sql
@@ -1,0 +1,133 @@
+-- 10_feature_view.sql — assemble the modeling matrix, one row per (MOVIE_ID, DAYS_OUT).
+-- Replace {{SANDBOX_DB}}. This is an illustrative-but-faithful reconstruction of the
+-- demand-forward feature set — NOT a 1:1 copy of any production view.
+--
+-- Design choices that mirror the reference model:
+--  * Grain = one row per film per pre-release horizon (DAYS_OUT in -21/-14/-7/-3), so the
+--    demand signals AND the comment signals are read as-of each horizon.
+--  * COMMENT FEATURES ARE AS-OF, NOT WHOLE-THREAD. Each horizon counts only comments
+--    posted on or before that horizon's date. Two reasons, neither dramatic: the horizon
+--    grain is meaningless if a film's -21 and -3 rows carry identical comment counts, and a
+--    thread scraped long after release includes post-release comments that are partly a
+--    consequence of the opening. The correction is small in practice -- on the reference
+--    corpus 78% of comments arrive within 5 days of the trailer and 94% before release, so
+--    only ~6% is post-release. Tripwire 1 below confirms the filter is biting.
+--  * Feature families: trailer conversation (volume + decomposed intent + sentiment),
+--    search & pageview DEMAND percentiles, genre/rating/runtime/season, quality-adjusted
+--    demand, and demand-gated pedigree interactions.
+--  * PEDIGREE IS GATED: budget / star power / predecessor gross / IP tier are NOT used as
+--    standalone features. They enter ONLY multiplied by demand (e.g. SEARCH7_X_STAR), so the
+--    model can't lean on hype the crowd isn't backing. See docs/06_model_overview.md.
+--  * NO leakage feature (a live popularity score) — deliberately absent.
+
+USE SCHEMA {{SANDBOX_DB}}.RESEARCH;
+
+CREATE OR REPLACE VIEW OW_FEATURES AS
+WITH comment_agg AS (
+    -- One aggregate per (film, horizon), using ONLY comments posted on or before that
+    -- horizon's as-of date. The COMMENT_DATE predicate is the leakage guard -- do not
+    -- remove it to "get more data", that is exactly the trade that invalidates the test.
+    SELECT
+        dp.MOVIE_ID,
+        dp.DAYS_OUT,
+        COUNT(*)                                            AS YT_COMMENTS,
+        LN(1 + COUNT(*))                                    AS LOG_YT,
+        AVG(s.SENTIMENT_SCORE)                              AS AVG_SENT,
+        100.0*AVG(s.THEATRICAL_INTENT)                      AS PCT_THEA,
+        100.0*AVG(s.PASS_INTENT)                            AS PCT_PASS,
+        100.0*AVG(IFF(s.SENTIMENT_BUCKET='positive',1,0))   AS PCT_POS,
+        100.0*AVG(IFF(s.SENTIMENT_BUCKET='negative',1,0))   AS PCT_NEG,
+        100.0*(AVG(s.THEATRICAL_INTENT) - AVG(s.PASS_INTENT)) AS NET_INTENT_PCT
+    FROM DEMAND_PERCENTILES dp
+    JOIN RELEASE_DATES rd0          ON rd0.MOVIE_ID = dp.MOVIE_ID
+    JOIN TRAILER_COMMENTS_SCORED s  ON s.MOVIE_ID = dp.MOVIE_ID
+                                   AND s.COMMENT_DATE <= DATEADD(day, dp.DAYS_OUT, rd0.RELEASE_DATE)
+    GROUP BY dp.MOVIE_ID, dp.DAYS_OUT
+)
+SELECT
+    -- keys / grain
+    dp.MOVIE_ID,
+    m.MOVIE_TITLE,
+    rd.RELEASE_DATE,
+    dp.DAYS_OUT,
+    -- target
+    bo.OPENING_WEEKEND,
+    LN(bo.OPENING_WEEKEND)                                          AS LOG_OPENING_WEEKEND,
+    bo.THEATER_COUNT,
+
+    -- ── Source B: the core signal (volume + decomposed intent + sentiment) ──
+    c.YT_COMMENTS,
+    c.LOG_YT,
+    c.AVG_SENT,
+    c.PCT_THEA, c.PCT_PASS, c.PCT_POS, c.PCT_NEG,
+    c.NET_INTENT_PCT,
+
+    -- ── Sources A + C: demand percentiles as of this horizon ──
+    dp.SEARCH_ROLLING_3D_PCTILE, dp.SEARCH_ROLLING_7D_PCTILE, dp.SEARCH_ROLLING_14D_PCTILE,
+    dp.SEARCH_PEAK_PCTILE, dp.SEARCH_VEL_PCTILE, dp.SEARCH_SLOPE_PCTILE,
+    dp.PAGEVIEW_R7D_PCTILE, dp.PAGEVIEW_PEAK_PCTILE, dp.PAGEVIEW_CUM_PCTILE, dp.PAGEVIEW_VEL_PCTILE,
+
+    -- ── calendar / content (standalone is fine for these) ──
+    MONTH(rd.RELEASE_DATE)                                         AS RELEASE_MONTH,
+    IFF(MONTH(rd.RELEASE_DATE) IN (5,6,7,11,12), 1, 0)             AS IS_PEAK_SEASON,
+    m2.RUNTIME,
+    m2.GENRE_ACTION_FRANCHISE, m2.GENRE_HORROR, m2.GENRE_ANIMATION_FAMILY, m2.GENRE_ORIGINAL,
+    m2.RATING_G, m2.RATING_PG, m2.RATING_PG13, m2.RATING_R,
+
+    -- ── quality-adjusted demand: demand weighted by how the intent leans ──
+    (1/(1+EXP(-0.2*c.NET_INTENT_PCT)))                             AS QMULT,
+    dp.SEARCH_ROLLING_7D_PCTILE * (1/(1+EXP(-0.2*c.NET_INTENT_PCT))) AS QADJ_SEARCH,
+    dp.PAGEVIEW_PEAK_PCTILE     * (1/(1+EXP(-0.2*c.NET_INTENT_PCT))) AS QADJ_PAGEVIEW,
+
+    -- ── demand-gated PEDIGREE interactions (pedigree only counts when demand backs it) ──
+    dp.SEARCH_ROLLING_7D_PCTILE * m2.MAX_STAR_POWER                AS SEARCH7_X_STAR,
+    dp.SEARCH_ROLLING_7D_PCTILE * m2.IP_HIGH_PROFILE               AS SEARCH7_X_IP_HIGH,
+    dp.SEARCH_ROLLING_7D_PCTILE * m2.PREDECESSOR_OW_LOG            AS SEARCH7_X_PREDOW,
+    dp.SEARCH_ROLLING_7D_PCTILE * m2.GENRE_ACTION_FRANCHISE        AS SEARCH7_X_ACTION,
+    dp.SEARCH_ROLLING_7D_PCTILE * m2.GENRE_HORROR                  AS SEARCH7_X_HORROR,
+    dp.PAGEVIEW_PEAK_PCTILE     * m2.MAX_STAR_POWER                AS PAGEVIEWPK_X_STAR,
+
+    -- ── intent × demand interactions ──
+    c.AVG_SENT       * dp.SEARCH_ROLLING_7D_PCTILE                 AS SENT_X_SEARCH7,
+    c.PCT_THEA       * dp.SEARCH_ROLLING_7D_PCTILE                 AS THEA_X_SEARCH7,
+    c.NET_INTENT_PCT * dp.SEARCH_ROLLING_7D_PCTILE                 AS NET_X_SEARCH7,
+    c.NET_INTENT_PCT * dp.PAGEVIEW_PEAK_PCTILE                     AS NET_X_PAGEVIEWPK,
+    c.AVG_SENT       * dp.PAGEVIEW_PEAK_PCTILE                     AS SENT_X_PAGEVIEWPK,
+    c.PCT_THEA       * dp.PAGEVIEW_PEAK_PCTILE                     AS THEA_X_PAGEVIEWPK
+
+FROM DEMAND_PERCENTILES dp
+JOIN MOVIE_MAP m                 ON dp.MOVIE_ID = m.MOVIE_ID
+JOIN RELEASE_DATES rd            ON dp.MOVIE_ID = rd.MOVIE_ID
+JOIN BOX_OFFICE bo               ON dp.MOVIE_ID = bo.MOVIE_ID
+LEFT JOIN comment_agg c          ON dp.MOVIE_ID = c.MOVIE_ID AND dp.DAYS_OUT = c.DAYS_OUT
+LEFT JOIN MOVIE_METADATA m2      ON dp.MOVIE_ID = m2.MOVIE_ID
+WHERE dp.MOVIE_ID NOT IN (SELECT MOVIE_ID FROM REMOVE_FROM_MODEL)
+  AND bo.OPENING_WEEKEND IS NOT NULL
+  AND (bo.THEATER_COUNT >= 1000 OR bo.THEATER_COUNT IS NULL)
+  AND COALESCE(m2.GENRE_PRESTIGE, 0) = 0;      -- reference model scopes out awards-season prestige
+
+
+-- ---------------------------------------------------------------------------
+-- Leakage tripwires — run all three. They cost seconds and they are the difference
+-- between a research result and a self-deception.
+-- ---------------------------------------------------------------------------
+-- 1. Comment volume must GROW with the horizon. If YT_COMMENTS is flat across
+--    -21/-14/-7/-3 for a film, the as-of filter is not biting (usually because
+--    COMMENT_DATE is NULL in TRAILER_COMMENTS_SCORED).
+--    SELECT DAYS_OUT, COUNT(*) AS films, ROUND(AVG(YT_COMMENTS)) AS avg_comments
+--    FROM OW_FEATURES GROUP BY 1 ORDER BY 1;
+--    Expect avg_comments to rise monotonically from -21 to -3.
+--
+-- 2. No NULL COMMENT_DATE.
+--    SELECT COUNT_IF(COMMENT_DATE IS NULL) FROM TRAILER_COMMENTS_SCORED;   -- expect 0
+--
+-- 3. Feature-label correlations should be in a plausible range. These are noisy real-world
+--    signals; a near-perfect correlation with the label means you are looking at something
+--    downstream of the outcome, not at demand.
+--    SELECT CORR(LOG_YT, LOG_OPENING_WEEKEND)            AS r_volume,
+--           CORR(SEARCH_ROLLING_7D_PCTILE, LOG_OPENING_WEEKEND) AS r_search,
+--           CORR(NET_INTENT_PCT, LOG_OPENING_WEEKEND)    AS r_intent
+--    FROM OW_FEATURES WHERE DAYS_OUT = -3;
+--    The reference build lands near r_volume 0.74 (0.54 once production budget is controlled;
+--    unchanged when trailer views are controlled) and r_intent ~0.2. Yours will differ with your film set. A r_volume of 0.95,
+--    though, is not a better dataset -- it means post-release comments are in the aggregate.

--- a/samples/boxoffice-signal-ml-starter/sql/20_intent_scoring_aisql.sql
+++ b/samples/boxoffice-signal-ml-starter/sql/20_intent_scoring_aisql.sql
@@ -1,0 +1,76 @@
+-- 20_intent_scoring_aisql.sql — score trailer comments with Snowflake Cortex AISQL.
+-- Turns raw comment text into SENTIMENT (via AI_SENTIMENT) + VIEWING INTENT
+-- (theatrical / streaming / pass / neutral) via a single structured TRY_COMPLETE call.
+-- Replace {{SANDBOX_DB}}. Requires access to Cortex AISQL functions (see docs/02).
+--
+-- This is a TEMPLATE. Model names and AISQL signatures evolve — ask CoCo:
+-- "update this to the current Cortex AISQL syntax and a good available model."
+--
+-- Two lessons baked in from real scoring runs:
+--  * Classify intent with ONE consolidated call into 4 labels — not several yes/no calls.
+--    Independent per-label flags over-fire; a single call is markedly more accurate.
+--  * Use the messages-array form with a `response_format` enum, and prefer TRY_COMPLETE:
+--    it returns NULL on a bad row instead of failing the whole batch. NULL is treated as
+--    NEUTRAL below, so the scored table has no missing intents.
+--  * CARRY COMMENT_DATE THROUGH. The feature view needs it to compute comment features
+--    as-of each pre-release horizon. Dropping it forces you to aggregate the whole
+--    thread into every horizon, which leaks release-week conversation into a -21 row.
+--
+-- MEASURE THIS BEFORE YOU TRUST IT: run sql/30_intent_eval.sql against hand-labeled gold
+-- comments and look at macro-F1 per class. The prompt below is the result of several
+-- rounds of exactly that loop; yours will need its own.
+
+USE SCHEMA {{SANDBOX_DB}}.RESEARCH;
+
+-- Score each raw comment: sentiment label (AI_SENTIMENT) + one intent label (TRY_COMPLETE),
+-- then map to the numeric score + 1/0 intent flags the feature view expects.
+INSERT INTO TRAILER_COMMENTS_SCORED
+    (MOVIE_ID, COMMENT_ID, COMMENT_TEXT, LIKE_COUNT, COMMENT_DATE,
+     SENTIMENT_SCORE, SENTIMENT_BUCKET, THEATRICAL_INTENT, STREAMING_INTENT, PASS_INTENT)
+WITH scored AS (
+    SELECT
+        r.MOVIE_ID,
+        r.COMMENT_ID,
+        r.COMMENT_TEXT,
+        r.LIKE_COUNT,
+        r.COMMENT_DATE,
+        AI_SENTIMENT(r.COMMENT_TEXT):categories[0]:sentiment::STRING            AS sent_label,
+        SNOWFLAKE.CORTEX.TRY_COMPLETE(
+            'claude-4-sonnet',
+            [
+              {'role':'system','content':
+                'Label a single movie-trailer comment with the COMMENTER''S OWN viewing intent, as exactly one of four labels. '
+                || 'THEATRICAL = explicit first-person intent to see it in a cinema (buying tickets, opening night, going to see it). '
+                || 'STREAMING = explicit intent to watch at home — stream, rent, buy the disc, etc. ("wait for streaming", "catch it on Prime", "Blu-ray day one"). '
+                || 'PASS = explicit intent to AVOID seeing it ("hard pass", "not wasting my money", "saves me a trip"). '
+                || 'NEUTRAL = everything else. Hype/excitement, naming a format ("only in theaters", "IMAX", "8K TV"), and general praise or criticism with NO stated personal viewing intent are all NEUTRAL. '
+                || 'General negativity ("bad movie", "looks awful", "woke garbage") is NEUTRAL, not PASS — tone is scored separately and PASS must not double-count it. '
+                || 'When in doubt, choose NEUTRAL.'},
+              {'role':'user','content': r.COMMENT_TEXT}
+            ],
+            {'response_format':{'type':'json','schema':{'type':'object',
+              'properties':{'intent':{'type':'string','enum':['THEATRICAL','STREAMING','PASS','NEUTRAL']}},
+              'required':['intent']}}}
+        ):structured_output[0]:raw_message:intent::STRING                       AS intent_label
+    FROM TRAILER_COMMENTS_RAW r
+    WHERE r.COMMENT_TEXT IS NOT NULL
+)
+SELECT
+    MOVIE_ID,
+    COMMENT_ID,
+    COMMENT_TEXT,
+    LIKE_COUNT,
+    COMMENT_DATE,
+    -- AI_SENTIMENT returns a label; map it to a numeric score the feature view can average
+    CASE sent_label WHEN 'positive' THEN 1 WHEN 'negative' THEN -1 ELSE 0 END   AS SENTIMENT_SCORE,
+    sent_label                                                                  AS SENTIMENT_BUCKET,
+    -- NEUTRAL and any NULL (unparseable / TRY_COMPLETE failure) collapse to all-zero
+    IFF(intent_label = 'THEATRICAL', 1, 0)                                      AS THEATRICAL_INTENT,
+    IFF(intent_label = 'STREAMING',  1, 0)                                      AS STREAMING_INTENT,
+    IFF(intent_label = 'PASS',       1, 0)                                      AS PASS_INTENT
+FROM scored;
+
+
+--          100.0*AVG(PASS_INTENT)                               AS pct_pass,
+--          100.0*(AVG(THEATRICAL_INTENT) - AVG(PASS_INTENT))    AS net_intent_pct
+--   FROM TRAILER_COMMENTS_SCORED GROUP BY MOVIE_ID;

--- a/samples/boxoffice-signal-ml-starter/sql/30_intent_eval.sql
+++ b/samples/boxoffice-signal-ml-starter/sql/30_intent_eval.sql
@@ -1,0 +1,137 @@
+-- 30_intent_eval.sql — measure the intent classifier against hand-labeled gold comments.
+-- Replace {{SANDBOX_DB}}. Run this BEFORE you believe any model result.
+--
+-- WHY THIS FILE EXISTS
+-- The whole method rests on one claim: an LLM can read a comment and tell you whether
+-- the person intends to buy a ticket, wait for streaming, or skip. If you never measure
+-- that, you are not doing research on audience intent -- you are doing research on a
+-- prompt. A classifier that systematically mistakes generic hype for THEATRICAL will
+-- produce a net-intent feature that mostly encodes "how excited does this thread sound",
+-- which is the gameable signal you were trying to get away from.
+--
+-- Everything here is provider-neutral and needs no data beyond your own labels.
+
+USE SCHEMA {{SANDBOX_DB}}.RESEARCH;
+
+-- ---------------------------------------------------------------------------
+-- Step 1 — Build a gold set (do this by hand; there is no shortcut)
+-- ---------------------------------------------------------------------------
+-- Sample 150-300 comments STRATIFIED by predicted label, so you get enough of the rare
+-- classes to say anything about them. A random sample will be ~85% NEUTRAL and tell you
+-- almost nothing about PASS.
+--
+--   CREATE OR REPLACE TABLE INTENT_GOLD_QUEUE AS
+--   SELECT COMMENT_ID, COMMENT_TEXT,
+--          CASE WHEN THEATRICAL_INTENT = 1 THEN 'THEATRICAL'
+--               WHEN STREAMING_INTENT  = 1 THEN 'STREAMING'
+--               WHEN PASS_INTENT       = 1 THEN 'PASS'
+--               ELSE 'NEUTRAL' END AS PREDICTED_INTENT
+--   FROM TRAILER_COMMENTS_SCORED
+--   QUALIFY ROW_NUMBER() OVER (PARTITION BY PREDICTED_INTENT ORDER BY RANDOM()) <= 60;
+--
+-- Then label GOLD_INTENT yourself and insert into INTENT_GOLD. Two rules that keep the
+-- exercise honest:
+--   * Label from the text alone. Do not look at the model's guess first -- you will anchor.
+--   * Write the edge-case rules down as you go and apply them consistently. The ones that
+--     cost the most accuracy in practice:
+--       - Naming a format ("IMAX", "only in theaters") is NOT theatrical intent unless the
+--         commenter says they are going.
+--       - General negativity ("this looks awful") is NEUTRAL, not PASS. PASS requires
+--         stated avoidance. Tone is scored separately; letting it double-count into PASS
+--         is the single most common way net intent gets corrupted.
+--       - Questions ("is this a remake?") are NEUTRAL.
+
+-- ---------------------------------------------------------------------------
+-- Step 2 — Confusion matrix
+-- ---------------------------------------------------------------------------
+WITH pred AS (
+    SELECT s.COMMENT_ID,
+           CASE WHEN s.THEATRICAL_INTENT = 1 THEN 'THEATRICAL'
+                WHEN s.STREAMING_INTENT  = 1 THEN 'STREAMING'
+                WHEN s.PASS_INTENT       = 1 THEN 'PASS'
+                ELSE 'NEUTRAL' END AS PREDICTED_INTENT
+    FROM TRAILER_COMMENTS_SCORED s
+)
+SELECT g.GOLD_INTENT,
+       p.PREDICTED_INTENT,
+       COUNT(*) AS n
+FROM INTENT_GOLD g
+JOIN pred p USING (COMMENT_ID)
+GROUP BY 1, 2
+ORDER BY 1, 2;
+
+-- ---------------------------------------------------------------------------
+-- Step 3 — Per-class precision / recall / F1 and MACRO-F1
+-- Macro-F1 (unweighted mean across classes) is the number to report. Plain accuracy is
+-- misleading here because NEUTRAL dominates: a classifier that answers NEUTRAL to
+-- everything scores ~85% accuracy and is worthless.
+-- ---------------------------------------------------------------------------
+WITH pred AS (
+    SELECT s.COMMENT_ID,
+           CASE WHEN s.THEATRICAL_INTENT = 1 THEN 'THEATRICAL'
+                WHEN s.STREAMING_INTENT  = 1 THEN 'STREAMING'
+                WHEN s.PASS_INTENT       = 1 THEN 'PASS'
+                ELSE 'NEUTRAL' END AS PREDICTED_INTENT
+    FROM TRAILER_COMMENTS_SCORED s
+),
+joined AS (
+    SELECT g.GOLD_INTENT, p.PREDICTED_INTENT
+    FROM INTENT_GOLD g JOIN pred p USING (COMMENT_ID)
+),
+classes AS (
+    SELECT 'THEATRICAL' AS CLS UNION ALL SELECT 'STREAMING'
+    UNION ALL SELECT 'PASS'    UNION ALL SELECT 'NEUTRAL'
+),
+per_class AS (
+    SELECT c.CLS,
+           COUNT_IF(j.GOLD_INTENT = c.CLS)                                   AS support,
+           COUNT_IF(j.PREDICTED_INTENT = c.CLS AND j.GOLD_INTENT = c.CLS)    AS tp,
+           COUNT_IF(j.PREDICTED_INTENT = c.CLS AND j.GOLD_INTENT <> c.CLS)   AS fp,
+           COUNT_IF(j.PREDICTED_INTENT <> c.CLS AND j.GOLD_INTENT = c.CLS)   AS fn
+    FROM classes c CROSS JOIN joined j
+    GROUP BY c.CLS
+),
+scored AS (
+    SELECT CLS, support, tp, fp, fn,
+           IFF(tp + fp = 0, NULL, tp / (tp + fp)) AS precision,
+           IFF(tp + fn = 0, NULL, tp / (tp + fn)) AS recall
+    FROM per_class
+),
+f1 AS (
+    SELECT *,
+           IFF(COALESCE(precision,0) + COALESCE(recall,0) = 0, 0,
+               2 * precision * recall / (precision + recall)) AS f1
+    FROM scored
+)
+SELECT CLS                          AS intent_class,
+       support,
+       ROUND(precision, 3)          AS precision,
+       ROUND(recall, 3)             AS recall,
+       ROUND(f1, 3)                 AS f1,
+       ROUND((SELECT AVG(f1) FROM f1), 3)                       AS macro_f1,
+       (SELECT SUM(support) FROM f1)                            AS gold_n,
+       ROUND((SELECT SUM(tp) FROM f1) / (SELECT SUM(support) FROM f1), 3) AS accuracy
+FROM f1
+ORDER BY support DESC;
+
+-- ---------------------------------------------------------------------------
+-- HOW TO READ THE RESULT
+-- ---------------------------------------------------------------------------
+--  * Macro-F1 in the low 0.8s on a few-hundred-comment gold set is a good, usable
+--    classifier for this task. Below ~0.65, your net-intent feature is mostly noise and
+--    any lift you see downstream is probably volume leaking through it.
+--  * Look at PASS recall specifically. It is the hardest class, it is half of net intent,
+--    and it is where prompts fail quietly.
+--  * The single biggest accuracy jump in the reference build came from consolidating
+--    several yes/no calls into ONE call that must choose among four labels. Independent
+--    per-label flags over-fire and inflate both THEATRICAL and PASS at once, which can
+--    leave net intent looking stable while both components are wrong.
+--
+-- Report the macro-F1 alongside any model accuracy you publish. A prediction pipeline
+-- whose input classifier is unmeasured has an unmeasured error bar.
+--
+-- Ask CoCo:
+--   "Run sql/30_intent_eval.sql. If macro-F1 is under 0.75, propose three specific prompt
+--    changes based on which classes are confused in the matrix, rescore a 500-comment
+--    sample with each, and show me the macro-F1 for each variant before I rescore
+--    everything."


### PR DESCRIPTION
## Summary

Adds `samples/boxoffice-signal-ml-starter` — a method kit for predicting a commercial outcome from public pre-release conversation, guided end to end by Cortex Code. The worked example is opening-weekend box office, but the pattern applies anywhere public conversation precedes a commercial outcome (game launches, product releases, ticketed events).

The interesting part is not the domain, it's the discipline around the AI:

- **Cortex AISQL intent scoring, not sentiment counting.** One consolidated `TRY_COMPLETE` call classifies each comment into four viewing-intent labels. Independent per-label yes/no calls over-fire — that lesson is baked into the prompt and documented.
- **An evaluation harness for the classifier itself** (`sql/30_intent_eval.sql`): macro-F1 plus a per-class confusion matrix against hand labels. On the reference build, the production scorer measured macro-F1 0.65 while a revised prompt reached 0.85 on the same labels — a gap that is invisible from reading output.
- **As-of feature engineering.** Demand percentiles at −21/−14/−7/−3 day horizons where no feature can see past its own prediction date, plus three tripwires in `sql/10` that catch it when the filter silently breaks.
- **Strict walk-forward temporal validation** with a distributional regressor (CatBoost + ElasticNet blend, residual-mixture prediction intervals, calibrated demand-forward flag), and pedigree features gated behind demand so the model can't lean on hype the audience isn't backing.

## Runs in ten minutes with no data

```bash
cd samples/boxoffice-signal-ml-starter
pip install -r model/requirements.txt
python model/train_ow_model.py --sample
```

Synthetic data, no Snowflake connection required — a reviewer can verify the modeling path end to end before wiring up any source.

## Data, terms, and privacy

No data is included and **no provider is named or endorsed**. The `sources/` dossiers describe each signal by its characteristics — behavior, access patterns, known failure modes — and CoCo helps the user evaluate options against their own access and each provider's terms. Keys live only in a git-ignored `.env` (template included, names only), and comment author handles are pseudonymized on ingest.

## Checklist

- [x] New directory under `samples/` with a kebab-case name
- [x] `README.md` with what it does, prerequisites, and how to run it
- [x] All source included (7 docs, 5 source dossiers, 5 CoCo skills, 5 SQL files, runnable model)
- [x] Added to the root README under **ML and Data Science**
- [x] No credentials, tokens, account identifiers, or internal object names
- [x] Verified `--sample` runs clean from inside the sample directory
